### PR TITLE
dunfell support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PATTERN_azure-device-update := "^${LAYERDIR}/"
 # This is applicable where we are using appends files to adjust other recipes.
 BBFILE_PRIORITY_azure-device-update = "16"
 LAYERDEPENDS_azure-device-update = "swupdate"
-LAYERSERIES_COMPAT_azure-device-update  = "honister"
+LAYERSERIES_COMPAT_azure-device-update  = "dunfell"
 
 # Layer-specific configuration variables.
 # These values can/will be overriden by environment variables


### PR DESCRIPTION
Adds support for dunfell.

Very small changes.

We have run this meta layer for a while now, on a couple of devices. Mainly RaspberryPi 3b and CM4. In our lab and in production. And everything is working fine.

Would love to be able to create a PR for the repo [meta-iot-hub-device-update-delta](https://github.com/Azure/meta-iot-hub-device-update-delta)  as well.

Thanks