### PR TITLE
Update Open Telemetry to 1.13.0

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PATTERN_azure-device-update := "^${LAYERDIR}/"
 # This is applicable where we are using appends files to adjust other recipes.
 BBFILE_PRIORITY_azure-device-update = "16"
 LAYERDEPENDS_azure-device-update = "swupdate"
-LAYERSERIES_COMPAT_azure-device-update  = "honister kirkstone"
+LAYERSERIES_COMPAT_azure-device-update  = "honister kirkstone scarthgap"
 
 # Layer-specific configuration variables.
 # These values can/will be overriden by environment variables

--- a/recipes-azure-sdk-for-cpp/azure-sdk-for-cpp/azure-sdk-for-cpp/0002-fix-gcc13-base64-compile-error.patch
+++ b/recipes-azure-sdk-for-cpp/azure-sdk-for-cpp/azure-sdk-for-cpp/0002-fix-gcc13-base64-compile-error.patch
@@ -1,0 +1,55 @@
+commit 2f6088025328e631713e23fba26db2c2cf2c9586
+Author: adamdebreceni <64783590+adamdebreceni@users.noreply.github.com>
+Date:   Tue Aug 22 20:49:35 2023 +0000
+
+    Address gcc13 compilation  issue
+
+diff --git a/sdk/core/azure-core/inc/azure/core/base64.hpp b/sdk/core/azure-core/inc/azure/core/base64.hpp
+index 6f65a0b7..cc2a7054 100644
+--- a/sdk/core/azure-core/inc/azure/core/base64.hpp
++++ b/sdk/core/azure-core/inc/azure/core/base64.hpp
+@@ -10,6 +10,7 @@
+ #pragma once
+ 
+ #include <algorithm>
++#include <cstdint>
+ #include <stdexcept>
+ #include <string>
+ #include <vector>
+diff --git a/sdk/core/azure-core/inc/azure/core/uuid.hpp b/sdk/core/azure-core/inc/azure/core/uuid.hpp
+index fbf73004..1f660224 100644
+--- a/sdk/core/azure-core/inc/azure/core/uuid.hpp
++++ b/sdk/core/azure-core/inc/azure/core/uuid.hpp
+@@ -10,6 +10,8 @@
+ 
+ #include "azure/core/platform.hpp"
+ 
++#include <array>
++#include <cstdint>
+ #include <cstring>
+ #include <string>
+ 
+diff --git a/sdk/keyvault/azure-security-keyvault-keys/src/private/key_sign_parameters.hpp b/sdk/keyvault/azure-security-keyvault-keys/src/private/key_sign_parameters.hpp
+index de432c68..1d8c9944 100644
+--- a/sdk/keyvault/azure-security-keyvault-keys/src/private/key_sign_parameters.hpp
++++ b/sdk/keyvault/azure-security-keyvault-keys/src/private/key_sign_parameters.hpp
+@@ -9,6 +9,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 
+diff --git a/sdk/keyvault/azure-security-keyvault-keys/src/private/key_verify_parameters.hpp b/sdk/keyvault/azure-security-keyvault-keys/src/private/key_verify_parameters.hpp
+index 9dc335f4..71839caf 100644
+--- a/sdk/keyvault/azure-security-keyvault-keys/src/private/key_verify_parameters.hpp
++++ b/sdk/keyvault/azure-security-keyvault-keys/src/private/key_verify_parameters.hpp
+@@ -9,6 +9,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <string>
+ #include <vector>
+ 

--- a/recipes-azure-sdk-for-cpp/azure-sdk-for-cpp/azure-sdk-for-cpp_git.bb
+++ b/recipes-azure-sdk-for-cpp/azure-sdk-for-cpp/azure-sdk-for-cpp_git.bb
@@ -11,7 +11,12 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI = "git://github.com/Azure/azure-sdk-for-cpp.git;protocol=https;branch=main"
 
 SRCREV = "f757bb06e71adb829edcaf2867abc4e87c5aa23f"
-SRC_URI += "file://0001-Fixup-compiler-warning.patch"
+
+# Release: azure-identity_1.6.0
+#SRCREV = "41b3df3dd39b87e9366cc28198ac400b1b07699d"
+SRC_URI += "file://0001-Fixup-compiler-warning.patch \
+            file://0002-fix-gcc13-base64-compile-error.patch \
+            "
 PV = "1.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-azure-sdk-for-cpp/opentelemetry-cpp/opentelemetry-cpp_git.bb
+++ b/recipes-azure-sdk-for-cpp/opentelemetry-cpp/opentelemetry-cpp_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Opentelemetry"
-LICENSE = "Apache2.0"
+LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-azure-sdk-for-cpp/opentelemetry-cpp/opentelemetry-cpp_git.bb
+++ b/recipes-azure-sdk-for-cpp/opentelemetry-cpp/opentelemetry-cpp_git.bb
@@ -6,7 +6,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI = "git://github.com/open-telemetry/opentelemetry-cpp.git;protocol=https;branch=main"
 
-SRCREV = "52309ddc65e74e7309c7224cacf3cfb04730b2be"
+SRCREV = "4bd64c9a336fd438d6c4c9dad2e6b61b0585311f"
 PV = "1.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This pull request includes changes to the `conf/layer.conf` and `recipes-azure-sdk-for-cpp/opentelemetry-cpp/opentelemetry-cpp_git.bb` files. The primary changes include updating the compatibility series for Azure Device Update and updating the source revision for the OpenTelemetry C++ SDK.

Here are the key changes:

Compatibility series update:
* [`conf/layer.conf`](diffhunk://#diff-22294624f20f807485d85b0f15eac2e1dac979796d77182b94b4896eb103c243L14-R14): Updated `LAYERSERIES_COMPAT_azure-device-update` to include "scarthgap" in the compatibility series for Azure Device Update. This change allows the Azure Device Update to be compatible with the "scarthgap" version.

Source revision update:
* [`recipes-azure-sdk-for-cpp/opentelemetry-cpp/opentelemetry-cpp_git.bb`](diffhunk://#diff-69bd4cf3ef4d5369b576d572b0e1b279f80213b666b0dca5699ff49d930470bbL9-R9): Updated `SRCREV` to a new commit hash (version 1.13.0). This version contains fixes for 'undeclared uint8_t' error due to missing 'stdint.h' header. 