### PR TITLE
Improve adu pub key handling

### DIFF
--- a/recipes-azure-device-update/adu-pub-key/adu-pub-key.bb
+++ b/recipes-azure-device-update/adu-pub-key/adu-pub-key.bb
@@ -16,6 +16,15 @@ DEPENDS = "openssl-native"
 # ADUC_PRIVATE_KEY is the build host path to the .pem private key file to use to sign the image.
 # ADUC_PRIVATE_KEY_PASSWORD is the build host path to the .pass password file for the private key.
 
+do_configure() {
+    if [ -z "${ADUC_PRIVATE_KEY}" ]; then
+        bbfatal "The environment variable 'ADUC_PRIVATE_KEY' is not set or not included in BB_ENV_PASSTHROUGH_ADDITIONS."
+    fi
+    if [ -z "${ADUC_PRIVATE_KEY_PASSWORD}" ]; then
+        bbfatal "The environment variable 'ADUC_PRIVATE_KEY_PASSWORD' is not set or not included in BB_ENV_PASSTHROUGH_ADDITIONS."
+    fi
+}
+
 # Generate the public key file using openssl, private key, and password file.
 do_compile() {
     openssl rsa -in ${ADUC_PRIVATE_KEY} -passin file:${ADUC_PRIVATE_KEY_PASSWORD} -out public.pem -outform PEM -pubout

--- a/recipes-azure-device-update/adu-pub-key/adu-pub-key.bb
+++ b/recipes-azure-device-update/adu-pub-key/adu-pub-key.bb
@@ -13,21 +13,32 @@ DEPENDS = "openssl-native"
 # openssl genrsa -aes256 -passout file:priv.pass -out priv.pem
 
 # These variables can be overriden via whitelisted environment variables:
+# ADUC_PUBLIC_KEY is the build host path to the .pem public key file to use for verifying the image.
 # ADUC_PRIVATE_KEY is the build host path to the .pem private key file to use to sign the image.
 # ADUC_PRIVATE_KEY_PASSWORD is the build host path to the .pass password file for the private key.
+# You can either specify the public key file using ADUC_PUBLIC_KEY
+# or alternatively let the public key be extracted from the private key given using ADUC_PRIVATE_KEY*.
 
 do_configure() {
-    if [ -z "${ADUC_PRIVATE_KEY}" ]; then
-        bbfatal "The environment variable 'ADUC_PRIVATE_KEY' is not set or not included in BB_ENV_PASSTHROUGH_ADDITIONS."
-    fi
-    if [ -z "${ADUC_PRIVATE_KEY_PASSWORD}" ]; then
-        bbfatal "The environment variable 'ADUC_PRIVATE_KEY_PASSWORD' is not set or not included in BB_ENV_PASSTHROUGH_ADDITIONS."
+    if [ -z "${ADUC_PUBLIC_KEY}" ]; then
+        if [ -z "${ADUC_PRIVATE_KEY}" ]; then
+            bbfatal "Neither 'ADUC_PUBLIC_KEY' nor 'ADUC_PRIVATE_KEY' environment variable is set or it is not included in BB_ENV_PASSTHROUGH_ADDITIONS."
+        fi
+
+        if [ -z "${ADUC_PRIVATE_KEY_PASSWORD}" ]; then
+            bbfatal "The environment variable 'ADUC_PRIVATE_KEY_PASSWORD' is not set or not included in BB_ENV_PASSTHROUGH_ADDITIONS."
+        fi
     fi
 }
 
-# Generate the public key file using openssl, private key, and password file.
+# Either take existing public key file or extract it from private key file using openssl, private key and password file.
 do_compile() {
-    openssl rsa -in ${ADUC_PRIVATE_KEY} -passin file:${ADUC_PRIVATE_KEY_PASSWORD} -out public.pem -outform PEM -pubout
+    if [ -z ${ADUC_PUBLIC_KEY} ]
+    then
+        openssl rsa -in ${ADUC_PRIVATE_KEY} -passin file:${ADUC_PRIVATE_KEY_PASSWORD} -out public.pem -outform PEM -pubout
+    else
+        cp ${ADUC_PUBLIC_KEY} public.pem
+    fi
 }
 
 # Install the public key file to ADUC_KEY_DIR


### PR DESCRIPTION
From a security perspective I want to minimize the use and availability of the private key in the build process.
For adu-pub-key using the public key directly would be enough.
Moreover, I added some better error handling in case of missing environment variables.

I'm using the kirkstone branch, so I opened my PR against kirkstone but I can also port that to scarthgap, too.

Thanks!