### PR TITLE
Add gen1 support to scarthgap

### DIFF
--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -25,7 +25,7 @@ ADU_GENERATION ?= "1"
 
 # For gen1, the release come out of develop branch, not main.
 ADU_GIT_BRANCH ?= "develop"
-ADU_SRC_URI ?= "git://github.com/Azure/iot-hub-device-update"
+ADU_SRC_URI ?= "https://github.com/Azure/iot-hub-device-update"
 SRC_URI ?= "${ADU_SRC_URI};protocol=https;branch=${ADU_GIT_BRANCH}"
 ADU_GIT_COMMIT ?= "350a551dd9d3f5639eddceb75ef5b10e834865fe"
 # CMake build types: "Release" "RelWithDebInfo" "MinSizeRel"
@@ -36,7 +36,7 @@ WITH_FEATURE_DELTA_UPDATE ?= "0"
 python() {
     try:
         adu_gen = d.getVar("ADU_GENERATION")
-        if adu_gen != "1" && adu_gen != "2":
+        if adu_gen != "1" and adu_gen != "2":
             bb.fatal(f"Invalid value '{adu_gen}' for ADU_GENERATION. Only '1' and '2' are allowed.")
         bb.note(f"Using adu_gen '{adu_gen}'")
 
@@ -104,8 +104,9 @@ S = "${WORKDIR}/git"
 # curl, DO agent, and DO SDK
 # Gen2 requires mosquitto recipe from openembedded meta-networking layer
 DEPENDS = "deliveryoptimization-agent deliveryoptimization-sdk curl azure-iot-sdk-c"
-DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-iot-sdk-c azure-sdk-for-cpp', '')}" # gen1-only
-DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '2', 'mosquitto', '')}"                         # gen2-only
+DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-iot-sdk-c', '', d)}"
+DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-sdk-for-cpp', '', d)}"
+DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '2', 'mosquitto', '', d)}"
 
 # Append to the build-time dependencies as per differences between Gen1 and Gen2
 #
@@ -156,7 +157,7 @@ EXTRA_OECMAKE += "-DADUC_INSTALL_DAEMON=OFF"
 EXTRA_OECMAKE += "-DDOSDK_INCLUDE_DIR=${WORKDIR}/recipe-sysroot/usr/include"
 EXTRA_OECMAKE += "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
 # cpprest installs its config.cmake file in a non-standard location.
-EXTRA_OECMAKE += "${@bb.utils.contains('ADU_GENERATION', '1', '-Dcpprestsdk_DIR=${WORKDIR}/recipe-sysroot/usr/lib/cmake', '', d)}"  # gen1-only
+EXTRA_OECMAKE += "${@bb.utils.contains('ADU_GENERATION', '1', '-Dcpprestsdk_DIR=${WORKDIR}/recipe-sysroot/usr/lib/cmake', '', d)}"
 
 # RDEPENDS are the RUNTIME dependencies that must be installed on the target
 # system for the cuurent package to function correctly.
@@ -209,7 +210,7 @@ USERADD_PARAM:${PN} = "\
     "
 
 do_compile[depends] += "azure-iot-sdk-c:do_prepare_recipe_sysroot"
-do_compile[depends] += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-sdk-for-cpp:do_prepare_recipe_sysroot', '')}"  # gen1-only
+do_compile[depends] += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-sdk-for-cpp:do_prepare_recipe_sysroot', '', d)}"
 
 do_install:append() {
     #create ADUC_DATA_DIR

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -40,7 +40,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 # Setup NTP servers (and fallbacks) to sync the date+time and not fail when
 # verifying the TLS server ca cert due to "notBefore" property.
 SRC_URI += "file://timesyncd.conf"
-do_install_append() {
+do_install:append() {
     install -d ${D}${sysconfdir}/systemd
     install -m 0644 ${WORKDIR}/timesyncd.conf ${D}${sysconfdir}/systemd/
 }

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -34,9 +34,6 @@ ADU_GIT_COMMIT ?= "350a551dd9d3f5639eddceb75ef5b10e834865fe"
 BUILD_TYPE ?= "Debug"
 WITH_FEATURE_DELTA_UPDATE ?= "0"
 
-# We are going to be adding extra files for both gen1 and gen2
-FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-
 # Setup NTP servers (and fallbacks) to sync the date+time and not fail when
 # verifying the TLS server ca cert due to "notBefore" property.
 # See do_install:append() below for where it installs timesyncd.conf

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -19,65 +19,78 @@ LICENSE = "CLOSED"
 # These will not be set to the values seen here if these are already set
 # in the environment's variables.
 #
-# # The release come out of develop branch, not main.
-# ADU_GIT_BRANCH ?= "develop"
-# ADU_SRC_URI ?= "git://github.com/Azure/iot-hub-device-update"
-# SRC_URI = "${ADU_SRC_URI};protocol=https;branch=${ADU_GIT_BRANCH}"
-# ADU_GIT_COMMIT ?= "60bb98ae3631419b393c528f7dc3cf0797b231e6"
-# # CMake build types: "Release" "RelWithDebInfo" "MinSizeRel"
-# BUILD_TYPE ?= "Debug"
-# # The agent generation. Can be "1" or "2". Gen1 uses IoTHub. Gen2 uses any MQTT broker.
-# ADU_AGENT_GEN ?= "1"
 
-# Using Gen2 for now. TODO: allow switching between gen1 and gen2 via ADU_AGENT_GEN env var
-ADU_GIT_BRANCH ?= "main"
-ADU_GIT_COMMIT ?= "e981f7a9af5f561f98a3be9ea9563f4d0f256e63"
-ADU_SRC_URI ?= "git://github.com/Azure/device-update"
+# # The agent generation. Can be "1" or "2"
+ADU_GENERATION ?= "1"
 
-SRC_URI = "${ADU_SRC_URI};protocol=ssh;branch=${ADU_GIT_BRANCH}"
+# For gen1, the release come out of develop branch, not main.
+ADU_GIT_BRANCH ?= "develop"
+ADU_SRC_URI ?= "git://github.com/Azure/iot-hub-device-update"
+SRC_URI ?= "${ADU_SRC_URI};protocol=https;branch=${ADU_GIT_BRANCH}"
+ADU_GIT_COMMIT ?= "350a551dd9d3f5639eddceb75ef5b10e834865fe"
+# CMake build types: "Release" "RelWithDebInfo" "MinSizeRel"
+BUILD_TYPE ?= "Debug"
+WITH_FEATURE_DELTA_UPDATE ?= "0"
 
-#################################################
-# BEGIN - patch to make finding libmosquitto work in du agent repo cmake:
-#
-# This is to bring in patch to add additional cmake function for finding libmosquitto to make it
-# work for yocto recipe.
-FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-# Add the Findmosquitto.cmake file to your source
-SRC_URI += "file://Findmosquitto.cmake"
-# Copy the find module during configure
-do_configure:prepend() {
-    mkdir -p ${S}/cmake/modules/
-    cp ${WORKDIR}/Findmosquitto.cmake ${S}/cmake/modules/
+# Handle override of default vars with those for Gen2
+python() {
+    try:
+        adu_gen = d.getVar("ADU_GENERATION")
+        if adu_gen != "1" && adu_gen != "2":
+            bb.fatal(f"Invalid value '{adu_gen}' for ADU_GENERATION. Only '1' and '2' are allowed.")
+        bb.note(f"Using adu_gen '{adu_gen}'")
+
+        # Gen2 sample overrides only if the env vars are not already defined.
+        if adu_gen == "2":
+            git_url = "git://github.com/Azure/device-update"
+            git_branch = "main"
+            git_commit = "e9fad55211ce620e32de15e0c8d7b3525e447992"
+
+            if not d.getVar("ADU_GIT_BRANCH", True):
+                bb.note(f"  *** Setting ADU_GIT_BRANCH to: {git_branch}")
+                d.setVar("ADU_GIT_BRANCH", git_branch)
+
+            if not d.getVar("ADU_GIT_URL", True):
+                bb.note(f"  *** Setting ADU_GIT_URL to: {git_url}")
+                d.setVar("ADU_GIT_URL", git_url)
+
+            if not d.getVar("ADU_GIT_COMMIT", True):
+                bb.note(f"  *** Setting ADU_GIT_COMMIT to: {git_commit}")
+                d.setVar("ADU_GIT_COMMIT", git_commit)
+
+            #################################################
+            # BEGIN - patch pre-do_configure to make finding libmosquitto work in du agent repo cmake:
+            #
+            # This is to bring in patch to add additional cmake function for finding libmosquitto to make it
+            # work for yocto recipe.
+            #
+            # Add paths for custom files
+            d.prependVar('FILESEXTRAPATHS', '${THISDIR}/files:')   # FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+            d.appendVar('SRC_URI', ' file://Findmosquitto.cmake')  # SRC_URI += "file://Findmosquitto.cmake"
+
+            # Create configure_prepend function. The equivalent of:
+            #
+            # do_configure:prepend() {
+            #    mkdir -p ${S}/cmake/modules/
+            #    cp ${WORKDIR}/Findmosquitto.cmake ${S}/cmake/modules/
+            # }
+            #
+            # Copy the find module during configure
+            d.prependVar('do_configure', '''
+            mkdir -p ${S}/cmake/modules/
+            cp ${WORKDIR}/Findmosquitto.cmake ${S}/cmake/modules/
+            ''')
+
+            # Add extra CMake options
+            # EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/cmake/modules"
+            d.appendVar('EXTRA_OECMAKE', ' -DCMAKE_MODULE_PATH=${S}/cmake/modules')
+            # END - patch to make finding libmosquitto work in du agent repo cmake:
+            #################################################
+
+    except Exception as ex:
+        errorMessage = "Failed override of ADU_GIT_ vars based on ADU_GENERATION. An exception of type {0} occurred with message:\n{1} and Arguments:\n{2!r}".format(type(ex).__name__, str(ex), ex.args)
+        bb.fatal(errorMessage)
 }
-# Add to your existing EXTRA_OECMAKE variables
-EXTRA_OECMAKE += "-DCMAKE_MODULE_PATH=${S}/cmake/modules"
-#
-# END - patch to make finding libmosquitto work in du agent repo cmake:
-#################################################
-
-# # Override defaults with those for Gen2 if ADU_AGENT_GEN is "2" AND not present in environment vars
-# fakeroot python() {
-#     # ADU_GIT_BRANCH ?= "main"
-#    # ADU_SRC_URI ?= "git://github.com/Azure/device-update"
-#    # SRC_URI = "${ADU_SRC_URI};protocol=https;branch=${ADU_GIT_BRANCH}"
-#    # ADU_GIT_COMMIT ?= "5041bf8fc30aaea5098a5378e804a7f7fae7c902"
-#    if d.getVar("ADU_AGENT_GEN") == "2":
-#        git_url = "git://github.com/Azure/device-update"
-#        git_branch = "main"
-#        git_commit = "5041bf8fc30aaea5098a5378e804a7f7fae7c902"
-#
-#        if not d.getVar("ADU_GIT_BRANCH", True):
-#            bb.note(f"  *** Setting ADU_GIT_BRANCH to: {git_branch}")
-#            d.setVar("ADU_GIT_BRANCH", git_branch)
-#
-#        if not d.getVar("ADU_GIT_URL", True):
-#            bb.note(f"  *** Setting ADU_GIT_URL to: {git_url}")
-#            d.setVar("ADU_GIT_URL", git_url)
-#
-#        if not d.getVar("ADU_GIT_COMMIT", True):
-#            bb.note(f"  *** Setting ADU_GIT_COMMIT to: {git_commit}")
-#            d.setVar("ADU_GIT_COMMIT", git_commit)
-#}
 
 SRCREV = "${ADU_GIT_COMMIT}"
 
@@ -90,7 +103,9 @@ S = "${WORKDIR}/git"
 # Common Build Dependencies are:
 # curl, DO agent, and DO SDK
 # Gen2 requires mosquitto recipe from openembedded meta-networking layer
-DEPENDS = "deliveryoptimization-agent deliveryoptimization-sdk curl azure-iot-sdk-c mosquitto"
+DEPENDS = "deliveryoptimization-agent deliveryoptimization-sdk curl azure-iot-sdk-c"
+DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-iot-sdk-c azure-sdk-for-cpp', '')}" # gen1-only
+DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '2', 'mosquitto', '')}"                         # gen2-only
 
 # Append to the build-time dependencies as per differences between Gen1 and Gen2
 #
@@ -104,15 +119,6 @@ DEPENDS = "deliveryoptimization-agent deliveryoptimization-sdk curl azure-iot-sd
 # client is statically linked.
 # d.appendVar('DEPENDS', ' mosquitto-dev')
 #
-# Generation 1 Additional BUILD Dependencies are:
-#     azure-iot-sdk-c        -->  for communicating with IoT Hub
-#     and azure-sdk-for-cpp  -->  for diagnostics
-#python() {
-#    agent_gen = d.getVar('ADU_AGENT_GEN')
-#    if agent_gen != "2":
-#        d.appendVar('DEPENDS', ' azure-iot-sdk-c')
-#        d.appendVar('DEPENDS', ' azure-sdk-for-cpp')
-#}
 
 inherit cmake useradd
 
@@ -145,28 +151,26 @@ EXTRA_OECMAKE += "-DADUC_LOG_FOLDER=/adu/logs"
 EXTRA_OECMAKE += "-DADUC_CONF_FOLDER=/adu"
 # Don't install/configure the daemon, another bitbake recipe will do that.
 EXTRA_OECMAKE += "-DADUC_INSTALL_DAEMON=OFF"
-# cpprest installs its config.cmake file in a non-standard location.
-# Tell cmake where to find it.
-#
-##EXTRA_OECMAKE += "-Dcpprestsdk_DIR=${WORKDIR}/recipe-sysroot/usr/lib/cmake"
 #
 # Using the installed DO SDK include files.
 EXTRA_OECMAKE += "-DDOSDK_INCLUDE_DIR=${WORKDIR}/recipe-sysroot/usr/include"
 EXTRA_OECMAKE += "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+# cpprest installs its config.cmake file in a non-standard location.
+EXTRA_OECMAKE += "${@bb.utils.contains('ADU_GENERATION', '1', '-Dcpprestsdk_DIR=${WORKDIR}/recipe-sysroot/usr/lib/cmake', '', d)}"  # gen1-only
 
 # RDEPENDS are the RUNTIME dependencies that must be installed on the target
 # system for the cuurent package to function correctly.
 #
-# bash - for running shell scripts for install.
-# swupdate - to install update package.
+# bash - for running shell scripts for script handler update payloads.
+# swupdate - to install swupdate .swu swupdate v2 update payloads.
 # adu-pub-key - to install public key for update package verification.
 # adu-log-dir - to create the temporary log directory in the image.
 # deliveryoptimization-agent-service - to install the delivery optimization agent for downloads.
-# curl - for running the diagnostics component
+# curl - for running the diagnostics component, curl content downloader
+# azure-device-update-diffs - to include the recipe for github.com:azure/iot-hub-device-update-delta runtime shared lib for delta updates.
 #
-# Temporarily remove runtime dep on delta update diffs
-#RDEPENDS:${PN} += "bash swupdate  adu-pub-key adu-log-dir deliveryoptimization-agent-service azure-device-update-diffs curl openssl-bin nss ca-certificates"
 RDEPENDS:${PN} += "bash swupdate  adu-pub-key adu-log-dir deliveryoptimization-agent-service curl openssl-bin nss ca-certificates"
+RDEPENDS:${PN} += "${@bb.utils.contains('WITH_FEATURE_DELTA_UPDATE', '1', 'azure-device-update-diffs', '', d)}"
 
 ADUC_DATA_DIR ?= "/var/lib/adu"
 ADUC_EXTENSIONS_DIR ?= "${ADUC_DATA_DIR}/extensions"
@@ -205,7 +209,7 @@ USERADD_PARAM:${PN} = "\
     "
 
 do_compile[depends] += "azure-iot-sdk-c:do_prepare_recipe_sysroot"
-#do_compile[depends] += "azure-sdk-for-cpp:do_prepare_recipe_sysroot"
+do_compile[depends] += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-sdk-for-cpp:do_prepare_recipe_sysroot', '')}"  # gen1-only
 
 do_install:append() {
     #create ADUC_DATA_DIR
@@ -296,7 +300,7 @@ fakeroot python do_registerAgentExtensions() {
 
     except Exception as ex:
         errorMessage = "Failed to create DU Agent extension registration. An exception of type {0} occurred with message:\n{1} and Arguments:\n{2!r}".format(type(ex).__name__, str(ex), ex.args)
-        bb.error(errorMessage)
+        bb.fatal(errorMessage)
 }
 do_registerAgentExtensions[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 addtask do_registerAgentExtensions after do_install before do_package

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -14,6 +14,8 @@
 #                       These values are the same as the CMAKE_BUILD_TYPE variable.
 
 LICENSE = "CLOSED"
+SUMMARY = "Azure Device Update agent for embedded GNU/Linux devices"
+MAINTAINER = "Microsoft Azure Device Update"
 
 # Defaults for Gen1
 # These will not be set to the values seen here if these are already set
@@ -25,8 +27,8 @@ ADU_GENERATION ?= "1"
 
 # For gen1, the release come out of develop branch, not main.
 ADU_GIT_BRANCH ?= "develop"
-ADU_SRC_URI ?= "https://github.com/Azure/iot-hub-device-update"
-SRC_URI ?= "${ADU_SRC_URI};protocol=https;branch=${ADU_GIT_BRANCH}"
+ADU_SRC_URI ?= "git://github.com/Azure/iot-hub-device-update"
+SRC_URI = "${ADU_SRC_URI};protocol=https;branch=${ADU_GIT_BRANCH}"
 ADU_GIT_COMMIT ?= "350a551dd9d3f5639eddceb75ef5b10e834865fe"
 # CMake build types: "Release" "RelWithDebInfo" "MinSizeRel"
 BUILD_TYPE ?= "Debug"

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -106,7 +106,6 @@ S = "${WORKDIR}/git"
 # curl, DO agent, and DO SDK
 # Gen2 requires mosquitto recipe from openembedded meta-networking layer
 DEPENDS = "deliveryoptimization-agent deliveryoptimization-sdk curl azure-iot-sdk-c"
-DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-iot-sdk-c', '', d)}"
 DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-sdk-for-cpp', '', d)}"
 DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '2', 'mosquitto', '', d)}"
 

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -39,11 +39,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 # Setup NTP servers (and fallbacks) to sync the date+time and not fail when
 # verifying the TLS server ca cert due to "notBefore" property.
+# See do_install:append() below for where it installs timesyncd.conf
 SRC_URI += "file://timesyncd.conf"
-do_install:append() {
-    install -d ${D}${sysconfdir}/systemd
-    install -m 0644 ${WORKDIR}/timesyncd.conf ${D}${sysconfdir}/systemd/
-}
 
 # Handle override of default vars with those for Gen2
 python() {
@@ -224,6 +221,10 @@ do_compile[depends] += "azure-iot-sdk-c:do_prepare_recipe_sysroot"
 do_compile[depends] += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-sdk-for-cpp:do_prepare_recipe_sysroot', '', d)}"
 
 do_install:append() {
+    # Install timesyncd.conf to setup NTP to sync the time correctly.
+    install -d ${D}${sysconfdir}/systemd
+    install -m 0644 ${WORKDIR}/timesyncd.conf ${D}${sysconfdir}/systemd/
+
     #create ADUC_DATA_DIR
     install -d ${D}${ADUC_DATA_DIR}
     chgrp ${ADUGROUP} ${D}${ADUC_DATA_DIR}

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -34,6 +34,17 @@ ADU_GIT_COMMIT ?= "350a551dd9d3f5639eddceb75ef5b10e834865fe"
 BUILD_TYPE ?= "Debug"
 WITH_FEATURE_DELTA_UPDATE ?= "0"
 
+# We are going to be adding extra files for both gen1 and gen2
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+# Setup NTP servers (and fallbacks) to sync the date+time and not fail when
+# verifying the TLS server ca cert due to "notBefore" property.
+SRC_URI += "file://timesyncd.conf"
+do_install_append() {
+    install -d ${D}${sysconfdir}/systemd
+    install -m 0644 ${WORKDIR}/timesyncd.conf ${D}${sysconfdir}/systemd/
+}
+
 # Handle override of default vars with those for Gen2
 python() {
     try:
@@ -67,7 +78,6 @@ python() {
             # work for yocto recipe.
             #
             # Add paths for custom files
-            d.prependVar('FILESEXTRAPATHS', '${THISDIR}/files:')   # FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
             d.appendVar('SRC_URI', ' file://Findmosquitto.cmake')  # SRC_URI += "file://Findmosquitto.cmake"
 
             # Create configure_prepend function. The equivalent of:

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -35,7 +35,7 @@ BUILD_TYPE ?= "Debug"
 WITH_FEATURE_DELTA_UPDATE ?= "0"
 
 # We are going to be adding extra files for both gen1 and gen2
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 # Setup NTP servers (and fallbacks) to sync the date+time and not fail when
 # verifying the TLS server ca cert due to "notBefore" property.

--- a/recipes-azure-device-update/azure-device-update/files/timesyncd.conf
+++ b/recipes-azure-device-update/azure-device-update/files/timesyncd.conf
@@ -1,0 +1,8 @@
+[Time]
+NTP=pool.ntp.org time.google.com time.windows.com
+FallbackNTP=0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org time1.google.com time2.google.com time3.google.com time4.google.com
+RootDistanceMaxSec=5
+PollIntervalMinSec=32
+PollIntervalMaxSec=2048
+ConnectionRetrySec=30
+SaveIntervalSec=60


### PR DESCRIPTION
This PR is a step towards iot-hub-device-update agent (gen1) agent support in poky scarthgap.
Running build.sh with corresponding PR https://github.com/Azure/iot-hub-device-update-yocto/pull/24 and tested using --adu-generation "1" and --adu-generation "2" to produce wic
It should help the conversation for issue #11

- Adds ADU_GENERATION environment variable condition and bb.fatal if value is not "1" or "2"
- Add logic to recipe parsing phase to setup ADU_GIT_* variables if not already overridden by defined env vars, including patching mosquitto to allow it to find_package mosquitto in CMake
- Use "${@bb.utils.contains(5 args)}" syntax to conditionally append DEPENDS, RDEPENDS, and EXTRA_OECMAKE accordingly based on ADU_GENERATION "1" or "2"
- Add RDEPENDS on delta updates recipe conditioned on new WITH_FEATURE_DELTA_UPDATE environment variable
- Use bb.fatal to terminate bitbake when python anonymous blocks throw exception
- Add Summary and Maintainer to recipe to fix qa issue notes