### PR TITLE
Update meta layer for IoT Hub Device Update support for Scarthgap

### DIFF
--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -43,6 +43,12 @@ BUILD_TYPE ?= "Debug"
 # Include DeltaUpdate Processor libary
 WITH_FEATURE_DELTA_UPDATE ?= "0"
 
+# Enable building unit tests (requires Catch2)
+WITH_ADUC_TESTS ?= "0"
+
+# Always include Catch2 as build dependency (some CMake may require it)
+WITH_ADUC_CATCH2_DEP ?= "1"
+
 # Setup NTP servers (and fallbacks) to sync the date+time and not fail when
 # verifying the TLS server ca cert due to "notBefore" property.
 # See do_install:append() below for where it installs timesyncd.conf
@@ -121,6 +127,7 @@ S = "${WORKDIR}/git"
 DEPENDS = "deliveryoptimization-agent deliveryoptimization-sdk curl azure-iot-sdk-c"
 DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-sdk-for-cpp', '', d)}"
 DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '2', 'mosquitto', '', d)}"
+DEPENDS += "${@bb.utils.contains('WITH_ADUC_CATCH2_DEP', '1', 'catch2', '', d)}"
 
 # Append to the build-time dependencies as per differences between Gen1 and Gen2
 #
@@ -174,6 +181,14 @@ EXTRA_OECMAKE += "${@bb.utils.contains('ADU_GENERATION', '1', '-Dcpprestsdk_DIR=
 # Enable Test Root Keys
 EXTRA_OECMAKE += "${@bb.utils.contains('ADU_EMBED_TEST_ROOT_KEYS', '1', '-DADUC_USE_TEST_ROOT_KEYS=true', '', d)}"
 EXTRA_OECMAKE += "${@bb.utils.contains('ADU_EMBED_TEST_ROOT_KEYS', '1', '-DADUC_ENABLE_E2E_TESTING=true', '', d)}"
+# Enable building unit tests with Catch2
+EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '1', '-DADUC_BUILD_UNIT_TESTS=ON', '-DADUC_BUILD_UNIT_TESTS=OFF', d)}"
+
+# Additional flags to completely disable all testing and test discovery  
+EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DBUILD_TESTING=OFF', '', d)}"
+EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DCATCH_BUILD_TESTING=OFF', '', d)}"
+EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DENABLE_TESTING=OFF', '', d)}"
+EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DCMAKE_DISABLE_TESTING=ON', '', d)}"
 
 # RDEPENDS are the RUNTIME dependencies that must be installed on the target
 # system for the cuurent package to function correctly.

--- a/recipes-devtools/catch2/catch2_3.8.0.bb
+++ b/recipes-devtools/catch2/catch2_3.8.0.bb
@@ -1,0 +1,38 @@
+SUMMARY = "Catch2 - A modern, C++-native, header-only test framework for unit-tests, TDD and BDD"
+DESCRIPTION = "Catch2 is a multi-paradigm test framework for C++. which also supports \
+Objective-C (and maybe C). It is primarily distributed as a single header file, \
+although certain extensions may require additional headers."
+HOMEPAGE = "https://github.com/catchorg/Catch2"
+LICENSE = "BSL-1.0"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
+
+SRC_URI = "git://github.com/catchorg/Catch2.git;protocol=https;branch=devel"
+SRCREV = "2b60af89e23d28eefc081bc930831ee9d45ea58b"
+
+S = "${WORKDIR}/git"
+
+inherit cmake
+
+# Catch2 requires C++14 or later
+CXXFLAGS:append = " -std=c++14"
+
+# Configure CMake options
+EXTRA_OECMAKE = " \
+    -DBUILD_TESTING=OFF \
+    -DCATCH_INSTALL_DOCS=OFF \
+    -DCATCH_INSTALL_EXTRAS=ON \
+"
+
+# Disable automatic test discovery for cross-compilation
+EXTRA_OECMAKE:append = " -DCATCH_BUILD_TESTING=OFF"
+
+# For development/testing builds, you might want to enable examples
+# EXTRA_OECMAKE += "-DCATCH_BUILD_EXAMPLES=ON"
+
+FILES:${PN}-dev += "${libdir}/cmake/Catch2/*"
+FILES:${PN}-dev += "${datadir}/Catch2/*"
+
+BBCLASSEXTEND = "native nativesdk"
+
+# This is a header-only library for the most part, but also provides
+# some CMake integration files that need to be packaged


### PR DESCRIPTION
  - Added bitbake for catch2 v3.8. and  configured for cross-compilation with proper CMake settings
  - Ensured that no unit tests are compiled by default