### PR TITLE
Modify Azure Device Update recipe able to control Catch2 dependency

### DIFF
--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -47,7 +47,7 @@ WITH_FEATURE_DELTA_UPDATE ?= "0"
 WITH_ADUC_TESTS ?= "0"
 
 # Include Catch2 as build dependency when tests are enabled
-# Set to "1" to always include Catch2 (safer), "0" to only include when tests enabled
+# Set to "1" to always include Catch2, "0" to never include it, or leave unset to inherit from WITH_ADUC_TESTS
 WITH_ADUC_CATCH2_DEP ?= "${WITH_ADUC_TESTS}"
 
 # Setup NTP servers (and fallbacks) to sync the date+time and not fail when

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -46,8 +46,9 @@ WITH_FEATURE_DELTA_UPDATE ?= "0"
 # Enable building unit tests (requires Catch2)
 WITH_ADUC_TESTS ?= "0"
 
-# Always include Catch2 as build dependency (some CMake may require it)
-WITH_ADUC_CATCH2_DEP ?= "1"
+# Include Catch2 as build dependency when tests are enabled
+# Set to "1" to always include Catch2 (safer), "0" to only include when tests enabled
+WITH_ADUC_CATCH2_DEP ?= "${WITH_ADUC_TESTS}"
 
 # Setup NTP servers (and fallbacks) to sync the date+time and not fail when
 # verifying the TLS server ca cert due to "notBefore" property.


### PR DESCRIPTION
The latest version of ADU Agent required a newer version of Catch2, which may cause a build error if other meta layer(s) depends on the version of Catch2. This change allows developer to remove Catch2 dependency (by disable ADU Agent Unit Tests)

WITH_ADUC_CATCH2_DEP controls whether to include Catch2 as a build dependency in the recipe.

By default, it's set to the same value as WITH_ADUC_TESTS (line 51), meaning Catch2 is only included when tests are enabled. However, you can override this behavior:

Set to "1" - Always include Catch2 as a build dependency (safer approach)
Set to "0" - Never include Catch2, even if tests are enabled
Default: inherits from WITH_ADUC_TESTS
The actual dependency addition happens on line 146:

```text
DEPENDS += "${@bb.utils.contains('WITH_ADUC_CATCH2_DEP', '1', 'catch2', '', d)}"
```

This variable provides flexibility to decouple Catch2 dependency from test building - useful if you want to include Catch2 for other reasons, or if you want to build tests but already have Catch2 available through another mechanism.