### PR TITLE
Sync feature/vnext-delta -> scarthgap (override divergent commits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 
 This project meta-azure-device-update serves as an example of embedding the Device Update agent in a custom Linux-based system.
 
+**Current Version:** 1.3.0 (LAYERVERSION=1)  
+**Yocto Compatibility:** Scarthgap (5.0)
+
+> **📋 IMPORTANT:** See [RELEASE-NOTES.md](RELEASE-NOTES.md) for breaking changes, migration guides, and detailed changelog.
+
 > **DISCLAIMER:**  
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-This is an example meta layer used for building the Device Update Image Diff Generator library. This library is required by the [Microsoft Delta Download Handler](https://github.com/Azure/iot-hub-device-update/tree/main/src/extensions/download_handlers/plugin_examples/microsoft_delta_download_handler).
+This layer provides recipes and configuration for integrating Azure Device Update (ADU) agent into Yocto-based embedded Linux systems. It includes the ADU client agent, Azure IoT SDK dependencies, Delivery Optimization agent, and supporting infrastructure for over-the-air (OTA) update management.
 
 # Recipes
 
@@ -13,7 +18,106 @@ This layer contains the following recipes:
 
 | Recipe Name      | Description |
 | ------------- | ---------- |
-| azure-device-update | Device Update for IoT Hub is a service that enables you to deploy over-the-air updates (OTA) for your IoT devices.<br/>For more information, see [Device Update for Iot Hub on Github](https://github.com/Azure/iot-hub-device-update) |
-| azure-iot-sdk-c | The Azure IoT device SDK is a set of libraries designed to simplify the process of sending messages to and receiving messages from the Azure IoT Hub service. The [Azure IoT device SDK for C](https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-device-sdk-c-intro) is required by [Device Update for Iot Hub](https://github.com/Azure/iot-hub-device-update)  |
-| azure-sdk-for-cpp | [The Azure SDK for C++](https://github.com/Azure/azure-sdk-for-cpp) is required by [Azure Blog Storage File Upload Utility](https://github.com/Azure/azure-blob-storage-file-upload-utility/blob/main/README.md) |
-| msft-gsl | The Guidelines Support Library (GSL) contains functions and types that are suggested for use by the C++ Core Guidelines maintained by the Standard C++ Foundation. This repo contains Microsoft's implementation of GSL. <br/> Many projects developed by Microsoft leverage this library.|
+| azure-device-update | Device Update for IoT Hub agent that manages OTA updates for IoT devices. Includes SWUpdate content handler, script handler, and step handler for orchestrating multi-step updates.<br/>For more information, see [Device Update for IoT Hub on Github](https://github.com/Azure/iot-hub-device-update) |
+| adu-agent-service | Systemd service configuration for the Azure Device Update agent. Manages the AducIotAgent daemon lifecycle and integration with system services. |
+| adu-config-setup | **NEW in v1.3:** Creates `/adu/` directory structure, manages symlinks for persistent configuration and data across A/B partition updates, and configures systemd-tmpfiles for log rotation. Consolidates functionality from deprecated adu-log-dir. |
+| adu-device-info-files | Installs device information files (manufacturer, model, version) that the ADU agent reads to report device identity to Azure IoT Hub. |
+| adu-pub-key | Installs RSA public key for verifying signed update packages. Required for secure update validation. |
+| deliveryoptimization-agent | Microsoft Delivery Optimization (DO) client agent for efficient content downloads with peer-to-peer support and bandwidth management. |
+| deliveryoptimization-agent-service | Systemd service configuration for the Delivery Optimization agent daemon. |
+| deliveryoptimization-sdk | Delivery Optimization SDK libraries required by the ADU agent for download management. |
+| azure-iot-sdk-c | The Azure IoT device SDK for C provides libraries for communicating with Azure IoT Hub. Required by Azure Device Update agent.<br/>For more information, see [Azure IoT SDK for C](https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-device-sdk-c-intro) |
+| azure-sdk-for-cpp | Azure SDK for C++ libraries. Required by Azure Blob Storage File Upload Utility.<br/>For more information, see [Azure SDK for C++](https://github.com/Azure/azure-sdk-for-cpp) |
+| catch2 | Catch2 testing framework. Required when building ADU agent with unit tests enabled (WITH_ADUC_TESTS=1). |
+| msft-gsl | Microsoft's implementation of the C++ Guidelines Support Library (GSL). Provides functions and types suggested by the C++ Core Guidelines. Required by many Microsoft C++ projects including ADU agent.<br/>For more information, see [MS-GSL on GitHub](https://github.com/microsoft/GSL) |
+
+---
+
+# Local Source Development
+
+This layer supports building from local source directories instead of fetching from GitHub. This is useful for:
+- Debugging issues in upstream repositories
+- Developing new features
+- Testing patches before submitting upstream
+- Working with private forks
+
+## Supported Repositories
+
+| Repository | Enable Variable | Path Variable | Default Path |
+|------------|-----------------|---------------|--------------|
+| **Azure Device Update** | `USE_LOCAL_ADU_SOURCE` | `ADU_LOCAL_SOURCE_DIR` | `${TOPDIR}/../../../sources/iot-hub-device-update` |
+| **Delivery Optimization** | `USE_LOCAL_DO_SOURCE` | `DO_LOCAL_SOURCE_DIR` | `${TOPDIR}/../../../sources/do-client` |
+| **Azure IoT SDK C** | `USE_LOCAL_AZIOT_SDK_C_SOURCE` | `AZIOT_SDK_C_LOCAL_SOURCE_DIR` | `${TOPDIR}/../../../sources/azure-iot-sdk-c` |
+
+## Usage
+
+### Method 1: Set in local.conf (Recommended)
+
+Add to your `build/conf/local.conf`:
+
+```bash
+# Enable local source for ADU
+USE_LOCAL_ADU_SOURCE = "1"
+ADU_LOCAL_SOURCE_DIR = "/path/to/iot-hub-device-update"
+
+# Enable local source for DO (optional)
+USE_LOCAL_DO_SOURCE = "1"
+DO_LOCAL_SOURCE_DIR = "/path/to/do-client"
+
+# Enable local source for Azure IoT SDK C (optional)
+USE_LOCAL_AZIOT_SDK_C_SOURCE = "1"
+AZIOT_SDK_C_LOCAL_SOURCE_DIR = "/path/to/azure-iot-sdk-c"
+```
+
+### Method 2: Environment Variables
+
+If setting via environment variables on the build host, add them to `BB_ENV_PASSTHROUGH_ADDITIONS` in your `build/conf/local.conf`:
+
+```bash
+BB_ENV_PASSTHROUGH_ADDITIONS += "USE_LOCAL_ADU_SOURCE ADU_LOCAL_SOURCE_DIR"
+BB_ENV_PASSTHROUGH_ADDITIONS += "USE_LOCAL_DO_SOURCE DO_LOCAL_SOURCE_DIR"
+BB_ENV_PASSTHROUGH_ADDITIONS += "USE_LOCAL_AZIOT_SDK_C_SOURCE AZIOT_SDK_C_LOCAL_SOURCE_DIR"
+```
+
+Then export the variables before building:
+
+```bash
+export USE_LOCAL_ADU_SOURCE=1
+export ADU_LOCAL_SOURCE_DIR=~/sources/iot-hub-device-update
+bitbake azure-device-update
+```
+
+### Method 3: Override in layer.conf
+
+The `conf/layer.conf` provides default values using the weak assignment operator `??=`, which means they can be overridden in your `local.conf` or higher-priority layers without conflict.
+
+## Important Notes
+
+- **GitHub fetch is disabled** when local source is enabled - the build uses your local directory directly
+- **Patches are NOT applied** - apply any needed patches manually to your local source
+- **Build artifacts** go to `<source>/build-yocto/` subdirectory
+- **Default paths are disabled** - local source feature is opt-in, disabled by default
+- Changes to local source are immediately reflected in builds (no git fetch)
+
+## Example Workflow
+
+```bash
+# Clone the repository
+mkdir -p ~/sources
+cd ~/sources
+git clone https://github.com/Azure/iot-hub-device-update
+cd iot-hub-device-update
+git checkout my-feature-branch
+
+# Make your changes
+vim src/agent/some_file.cpp
+
+# Add to local.conf
+echo 'USE_LOCAL_ADU_SOURCE = "1"' >> ~/build/conf/local.conf
+echo 'ADU_LOCAL_SOURCE_DIR = "~/sources/iot-hub-device-update"' >> ~/build/conf/local.conf
+
+# Build
+cd ~/build
+bitbake azure-device-update -c clean
+bitbake azure-device-update
+```

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -7,6 +7,10 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb \
 BBFILE_COLLECTIONS += "azure-device-update"
 BBFILE_PATTERN_azure-device-update := "^${LAYERDIR}/"
 
+# Layer version: increment for each incompatible change
+# See RELEASE-NOTES.md for detailed changelog
+LAYERVERSION_azure-device-update = "2"
+
 # Pri 16 ensures that our recipes are applied over other layers.
 # This is applicable where we are using appends files to adjust other recipes.
 BBFILE_PRIORITY_azure-device-update = "16"
@@ -36,6 +40,19 @@ MODEL ?= "ADU Raspberry Pi Example"
 # ADUC_PRIVATE_KEY is the build host path to the .pem private key file to use to sign the image.
 # ADUC_PRIVATE_KEY_PASSWORD is the build host path to the .pass password file for the private key.
 
+# Local source development mode (disabled by default)
+# Set these variables to use local source directories instead of fetching from GitHub
+# Useful for development and debugging. See README.md for usage examples.
+USE_LOCAL_ADU_SOURCE ??= "0"
+USE_LOCAL_DO_SOURCE ??= "0"
+USE_LOCAL_AZIOT_SDK_C_SOURCE ??= "0"
+
+# Default paths for local source repositories (relative to build directory)
+# Override via environment variables if needed
+ADU_LOCAL_SOURCE_DIR ??= "${TOPDIR}/../../../sources/iot-hub-device-update"
+DO_LOCAL_SOURCE_DIR ??= "${TOPDIR}/../../../sources/do-client"
+AZIOT_SDK_C_LOCAL_SOURCE_DIR ??= "${TOPDIR}/../../../sources/azure-iot-sdk-c"
+
 BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.%s' % (layer, ext) \
                for layer in '${BBFILE_COLLECTIONS}'.split() for ext in ['bb', 'bbappend'])}"
 
@@ -44,11 +61,8 @@ BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.%s' % (layer, ext) \
 INHERIT += "extrausers"
 
 # User / group settings
-# The settings are separated by the ; character.
-# Each setting is actually a command. The supported commands are useradd,
-# groupadd, userdel, groupdel, usermod and groupmod.
-EXTRA_USERS_PARAMS:append = "groupadd --gid 800 adu ; \
- groupadd -r --gid 801 do ; \
- useradd --uid 800 -p '' -r -g adu -G do --no-create-home --shell /bin/false adu ; \
- useradd --uid 801 -p '' -r -g do -G adu --no-create-home --shell /bin/false do ; \
- "
+# Note: adu and do users/groups are now defined in azure-device-update_git.bb recipe
+# using USERADD_PARAM/GROUPADD_PARAM (recipe-level user management via useradd class).
+# This is the preferred method as it ties user creation to the specific package.
+# Layer-level EXTRA_USERS_PARAMS should only be used for image-wide users not tied to specific packages.
+EXTRA_USERS_PARAMS:append = ""

--- a/recipes-azure-device-update/adu-agent-service/files/deviceupdate-agent.service
+++ b/recipes-azure-device-update/adu-agent-service/files/deviceupdate-agent.service
@@ -6,7 +6,7 @@ Wants=network-online.target deliveryoptimization-agent.service
 [Service]
 Type=simple
 Restart=always
-RestartSec=5
+RestartSec=30
 User=adu
 Group=adu
 # We can check logs with journalctl -f -u deviceupdate-agent.service --no-tail

--- a/recipes-azure-device-update/adu-config-setup/adu-config-setup_1.0.bb
+++ b/recipes-azure-device-update/adu-config-setup/adu-config-setup_1.0.bb
@@ -1,0 +1,149 @@
+# Recipe: adu-config-setup
+# Description: Setup persistent ADU configuration and data directories with symlinks
+# Purpose: Centralize ADU config in /adu/ and redirect standard Linux paths via symlinks
+
+SUMMARY = "Azure Device Update configuration setup and directory structure"
+DESCRIPTION = "Creates /adu/ directory structure for persistent ADU configuration and data, \
+               sets up symlinks from standard Linux locations to /adu/ paths, and configures \
+               systemd-tmpfiles for automatic directory maintenance."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://du-config.json \
+    file://du-config.json.template \
+    file://du-diagnostics-config.json \
+    file://adu-logs.conf \
+    file://adu-oobe.service \
+    file://setup-adu-dirs.sh \
+"
+
+S = "${WORKDIR}"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "adu-oobe.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+# Runtime dependency: azure-device-update creates adu and do users/groups
+# We need those users to exist before setting directory ownership
+RDEPENDS:${PN} = "azure-device-update"
+
+do_install() {
+    # =========================================================================
+    # Install setup script and systemd service
+    # =========================================================================
+    # The script creates directories on the mounted /adu partition (mmcblk0p4)
+    # This runs after adu.mount via systemd dependency
+    
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/setup-adu-dirs.sh ${D}${sbindir}/
+    
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/adu-oobe.service ${D}${systemd_system_unitdir}/
+    
+    # =========================================================================
+    # Install configuration templates to /usr/share/adu-config-templates
+    # =========================================================================
+    # These will be copied to /adu/conf by the setup script
+    # du-config.json is installed as a working default (with placeholder connection string)
+    # du-config.json.template is kept as reference for users to customize
+    
+    install -d ${D}${datadir}/adu-config-templates
+    install -m 0644 ${WORKDIR}/du-config.json ${D}${datadir}/adu-config-templates/
+    install -m 0644 ${WORKDIR}/du-config.json.template ${D}${datadir}/adu-config-templates/
+    install -m 0644 ${WORKDIR}/du-diagnostics-config.json ${D}${datadir}/adu-config-templates/
+    
+    # =========================================================================
+    # Install systemd-tmpfiles configuration
+    # =========================================================================
+    # This ensures /adu/logs directory is cleaned periodically (on /adu partition)
+    
+    install -d ${D}${sysconfdir}/tmpfiles.d
+    install -m 0644 ${WORKDIR}/adu-logs.conf ${D}${sysconfdir}/tmpfiles.d/
+    
+    # =========================================================================
+    # Create diagnostic log directory on boot partition
+    # =========================================================================
+    # This provides fallback logging when /adu mount fails
+    # /boot is always available (FAT32 boot partition)
+    
+    install -d ${D}/boot/adu-diagnostics
+}
+
+pkg_postinst_ontarget:${PN}() {
+    #!/bin/sh
+    set -e
+    
+    # Function to safely create symlink
+    create_symlink() {
+        local target="$1"
+        local link="$2"
+        
+        # If link already exists as a symlink pointing to target, nothing to do
+        if [ -L "$link" ] && [ "$(readlink "$link")" = "$target" ]; then
+            echo "Symlink $link -> $target already exists"
+            return 0
+        fi
+        
+        # If link exists but is not a symlink or points elsewhere
+        if [ -e "$link" ] || [ -L "$link" ]; then
+            echo "WARNING: $link exists but is not a symlink to $target"
+            echo "  Backing up to ${link}.backup and creating symlink"
+            mv "$link" "${link}.backup"
+        fi
+        
+        # Create parent directory if needed
+        mkdir -p "$(dirname "$link")"
+        
+        # Create the symlink
+        ln -sf "$target" "$link"
+        
+        # Set ownership of the symlink itself (not the target)
+        chown -h adu:adu "$link" 2>/dev/null || echo "WARNING: Could not set ownership on symlink $link"
+        
+        echo "Created symlink: $link -> $target (owner: adu:adu)"
+    }
+
+    # Create symlinks
+    create_symlink "/adu/conf" "/etc/adu"
+    # Ensure /adu/conf (target of /etc/adu symlink) has correct ownership and permissions
+    # Note: chmod/chown on a symlink changes the target, not the symlink itself
+    # Symlinks always show as lrwxrwxrwx, but target permissions control access
+    chown adu:adu /adu/conf 2>/dev/null || echo "WARNING: Could not set ownership on /adu/conf"
+    chmod 0750 /adu/conf 2>/dev/null || echo "WARNING: Could not set permissions on /adu/conf"
+    
+    create_symlink "/adu/logs" "/var/log/adu"
+
+    # # For /var/lib/adu/downloads, we need to ensure parent directory exists
+    # # but azure-device-update recipe creates /var/lib/adu, so this should exist
+    # if [ -d "/var/lib/adu" ]; then
+    #     create_symlink "/adu/data/downloads" "/var/lib/adu/downloads"
+    # else
+    #     echo "WARNING: /var/lib/adu does not exist yet, symlinking downloads may fail"
+    #     echo "  Creating /var/lib/adu and then symlinking..."
+    #     mkdir -p /var/lib/adu
+    #     chown adu:adu /var/lib/adu
+    #     chmod 0770 /var/lib/adu
+    #     create_symlink "/adu/data/downloads" "/var/lib/adu/downloads"
+    # fi
+
+exit 0
+}
+
+# Package files
+FILES:${PN} = " \
+    ${sbindir}/setup-adu-dirs.sh \
+    ${systemd_system_unitdir}/adu-oobe.service \
+    ${datadir}/adu-config-templates/* \
+    ${sysconfdir}/tmpfiles.d/adu-logs.conf \
+    /boot/adu-diagnostics \
+"
+
+# Allow empty directories to be packaged
+ALLOW_EMPTY:${PN} = "1"
+
+# Replaces the old adu-log-dir recipe functionality
+RPROVIDES:${PN} = "adu-log-dir"
+RREPLACES:${PN} = "adu-log-dir"
+RCONFLICTS:${PN} = "adu-log-dir"

--- a/recipes-azure-device-update/adu-config-setup/files/adu-logs.conf
+++ b/recipes-azure-device-update/adu-config-setup/files/adu-logs.conf
@@ -2,12 +2,10 @@
 # and is cleaned every 10 days.
 #
 # q - Create the directory or subvolume at boot if it does not exist.
-# L+ - Create or replace a symbolic link
 #   For more details see 'man tmpfiles.d'
-# 0774 - rwxrwxr-- Owner and group have full access, others read-only
+# 1777 - Read, Write, and Execute permissions for all
 # adu adu - Owner and group for the folder.
 # 10d - Cleanup this directory every 10 days.
 #
-# Type  Path            Mode  Owner  Group  Age  Argument
-q      /adu/logs       0774  adu    adu    10d  -
-L+     /var/log/adu    -     -      -      -    /adu/logs
+# mode path permissions owner group duration
+q /adu/logs 1777 adu adu 10d

--- a/recipes-azure-device-update/adu-config-setup/files/adu-oobe.service
+++ b/recipes-azure-device-update/adu-config-setup/files/adu-oobe.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=ADU Out-of-Box Experience - Bootstrap, verify, and maintain ADU partition structure
+Documentation=https://github.com/Azure/iot-hub-device-update
+Documentation=file:///usr/share/doc/adu-config-setup/README-ADU-OOBE-SERVICE.md
+After=adu.mount
+Requires=adu.mount
+Before=deviceupdate-agent.service adu-swap.service adu-boot-health.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/setup-adu-dirs.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-azure-device-update/adu-config-setup/files/du-config.json
+++ b/recipes-azure-device-update/adu-config-setup/files/du-config.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.2",
+  "aduShellTrustedUsers": [
+    "adu",
+    "do"
+  ],
+  "manufacturer": "contoso",
+  "model": "raspberrypi-yocto-adu-poc-1",
+  "agents": [
+    {
+      "name": "main",
+      "runas": "adu",
+      "connectionSource": {
+        "connectionType": "string",
+        "connectionData": "HostName=placeholder.azure-devices.net;DeviceId=placeholder-device;SharedAccessKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      },
+      "manufacturer": "contoso",
+      "model": "raspberrypi-yocto-adu-poc-1"
+    }
+  ]
+}

--- a/recipes-azure-device-update/adu-config-setup/files/du-config.json.template
+++ b/recipes-azure-device-update/adu-config-setup/files/du-config.json.template
@@ -12,7 +12,7 @@
       "runas": "adu",
       "connectionSource": {
         "connectionType": "string",
-        "connectionData": "HostName=placeholder.azure-devices.net;DeviceId=placeholder-device;SharedAccessKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        "connectionData": "HostName=placeholder.azure-devices.net;DeviceId=placeholder-device;SharedAccessKey="
       },
       "manufacturer": "contoso",
       "model": "raspberrypi-yocto-adu-poc-1"

--- a/recipes-azure-device-update/adu-config-setup/files/du-config.json.template
+++ b/recipes-azure-device-update/adu-config-setup/files/du-config.json.template
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "1.2",
+  "aduShellTrustedUsers": [
+    "adu",
+    "do"
+  ],
+  "manufacturer": "contoso",
+  "model": "raspberrypi-yocto-adu-poc-1",
+  "agents": [
+    {
+      "name": "main",
+      "runas": "adu",
+      "connectionSource": {
+        "connectionType": "string",
+        "connectionData": "HostName=placeholder.azure-devices.net;DeviceId=placeholder-device;SharedAccessKey=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+      },
+      "manufacturer": "contoso",
+      "model": "raspberrypi-yocto-adu-poc-1"
+    }
+  ]
+}

--- a/recipes-azure-device-update/adu-config-setup/files/du-config.json.template
+++ b/recipes-azure-device-update/adu-config-setup/files/du-config.json.template
@@ -12,7 +12,7 @@
       "runas": "adu",
       "connectionSource": {
         "connectionType": "string",
-        "connectionData": "HostName=placeholder.azure-devices.net;DeviceId=placeholder-device;SharedAccessKey="
+        "connectionData": "HostName=placeholder.azure-devices.net;DeviceId=placeholder-device;..."
       },
       "manufacturer": "contoso",
       "model": "raspberrypi-yocto-adu-poc-1"

--- a/recipes-azure-device-update/adu-config-setup/files/du-config.json.template
+++ b/recipes-azure-device-update/adu-config-setup/files/du-config.json.template
@@ -12,7 +12,7 @@
       "runas": "adu",
       "connectionSource": {
         "connectionType": "string",
-        "connectionData": "HostName=placeholder.azure-devices.net;DeviceId=placeholder-device;..."
+        "connectionData": "HostName=placeholder"
       },
       "manufacturer": "contoso",
       "model": "raspberrypi-yocto-adu-poc-1"

--- a/recipes-azure-device-update/adu-config-setup/files/du-diagnostics-config.json
+++ b/recipes-azure-device-update/adu-config-setup/files/du-diagnostics-config.json
@@ -1,0 +1,13 @@
+{
+    "logComponents":[
+        {
+            "componentName":"adu",
+            "logPath":"/var/log/adu/"
+        },
+        {
+            "componentName":"do",
+            "logPath":"/var/log/deliveryoptimization-agent/"
+        }
+    ],
+    "maxKilobytesToUploadPerLogPath":50
+}

--- a/recipes-azure-device-update/adu-config-setup/files/setup-adu-dirs.sh
+++ b/recipes-azure-device-update/adu-config-setup/files/setup-adu-dirs.sh
@@ -1,0 +1,691 @@
+#!/bin/sh
+# setup-adu-dirs.sh
+# Purpose: Bootstrap, verify, and maintain ADU directory structure on /adu partition
+# Phases: Bootstrap (first-time), Verify (every boot), Migrate (version changes), Repair (fix corruption)
+# This script runs via systemd service after the /adu partition is mounted
+
+# DO NOT use 'set -e' - we want explicit error handling with diagnostics
+set -u  # Exit on undefined variables
+
+# =========================================================================
+# Configuration
+# =========================================================================
+SCRIPT_VERSION="1.0"
+VERSION_FILE="/adu/.setup-version"
+TEMPLATE_DIR="/usr/share/adu-config-templates"
+LOG_PREFIX="[ADU-OOBE]"
+
+# Fallback logging when /adu is not available (critical for debugging mount failures)
+FALLBACK_LOG_DIR="/boot/adu-diags"
+FALLBACK_LOG="${FALLBACK_LOG_DIR}/oobe-failure.log"
+DIAG_SNAPSHOT="${FALLBACK_LOG_DIR}/oobe-snapshot.txt"
+
+# Error codes
+ERR_MOUNT_MISSING=1
+ERR_NOT_WRITABLE=2
+ERR_USER_MISSING=3
+ERR_MKDIR_FAILED=4
+ERR_CHOWN_FAILED=5
+ERR_TEMPLATE_FAILED=6
+
+# =========================================================================
+# Diagnostic Logging Functions
+# =========================================================================
+
+# Initialize fallback logging
+init_fallback_logging() {
+    if [ ! -d "$FALLBACK_LOG_DIR" ]; then
+        mkdir -p "$FALLBACK_LOG_DIR" 2>/dev/null || return 0
+    fi
+    # Start fresh log for this boot
+    echo "=== ADU OOBE Log - $(date) ===" > "$FALLBACK_LOG" 2>/dev/null || return 0
+}
+
+# Log to both systemd journal and fallback location
+log_both() {
+    local level="$1"
+    shift
+    local msg="$*"
+    
+    # To systemd journal (via stdout/stderr)
+    if [ "$level" = "ERROR" ] || [ "$level" = "WARNING" ]; then
+        echo "$LOG_PREFIX $level: $msg" >&2
+    else
+        echo "$LOG_PREFIX $level: $msg"
+    fi
+    
+    # To fallback log (for debugging when /adu fails)
+    if [ -w "$FALLBACK_LOG_DIR" ]; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') [$level] $msg" >> "$FALLBACK_LOG" 2>/dev/null || true
+    fi
+}
+
+log_info() {
+    log_both "INFO" "$@"
+}
+
+log_warn() {
+    log_both "WARNING" "$@"
+}
+
+log_error() {
+    log_both "ERROR" "$@"
+}
+
+# Create diagnostic snapshot for troubleshooting
+create_diagnostic_snapshot() {
+    local snapshot_file="${1:-$DIAG_SNAPSHOT}"
+    
+    if [ ! -w "$FALLBACK_LOG_DIR" ]; then
+        return 0
+    fi
+    
+    {
+        echo "=== ADU OOBE Diagnostic Snapshot ==="
+        echo "Timestamp: $(date)"
+        echo "Script Version: $SCRIPT_VERSION"
+        echo ""
+        
+        echo "--- Mount Status ---"
+        mount | grep -E '(adu|mmcblk0p4)' || echo "No /adu mount found"
+        echo ""
+        
+        echo "--- /adu Directory ---"
+        if [ -d /adu ]; then
+            ls -laR /adu 2>&1 || echo "Cannot list /adu"
+            df -h /adu 2>&1 || echo "Cannot get /adu filesystem info"
+        else
+            echo "/adu directory does not exist"
+        fi
+        echo ""
+        
+        echo "--- Users/Groups ---"
+        grep -E '^(adu|do):' /etc/passwd || echo "adu user not found"
+        grep -E '^(adu|do):' /etc/group || echo "adu group not found"
+        echo ""
+        
+        echo "--- Systemd Services ---"
+        systemctl status adu.mount 2>&1 | head -20 || echo "adu.mount not found"
+        systemctl status adu-oobe.service 2>&1 | head -20 || echo "adu-oobe.service not found"
+        echo ""
+        
+        echo "--- Disk Space ---"
+        df -h 2>&1
+        echo ""
+        
+        echo "--- Recent Journal Entries ---"
+        journalctl -u adu-oobe.service --no-pager -n 50 2>&1 || echo "Cannot read journal"
+        
+    } > "$snapshot_file" 2>&1
+    
+    log_info "Diagnostic snapshot saved to $snapshot_file"
+}
+
+# =========================================================================
+# Pre-Flight Checks
+# =========================================================================
+
+# Check if /adu is mounted and writable
+check_adu_mount() {
+    log_info "Pre-flight: Checking /adu mount status..."
+    
+    # Check if /adu exists
+    if [ ! -d /adu ]; then
+        log_error "/adu directory does not exist"
+        create_diagnostic_snapshot
+        return $ERR_MOUNT_MISSING
+    fi
+    
+    # Check if /adu is actually mounted (not just an empty dir in rootfs)
+    if ! mount | grep -q '/adu'; then
+        log_error "/adu is not mounted - expected /dev/mmcblk0p4 or similar"
+        log_error "Run: mount | grep adu"
+        create_diagnostic_snapshot
+        return $ERR_MOUNT_MISSING
+    fi
+    
+    # Check if /adu is writable
+    if ! touch /adu/.write-test 2>/dev/null; then
+        log_error "/adu is mounted but not writable"
+        log_error "Check: mount | grep adu (look for 'ro' flag)"
+        create_diagnostic_snapshot
+        return $ERR_NOT_WRITABLE
+    fi
+    rm -f /adu/.write-test
+    
+    log_info "Pre-flight: /adu is mounted and writable"
+    return 0
+}
+
+# Check if required users/groups exist
+check_users() {
+    log_info "Pre-flight: Checking adu:adu user/group..."
+    
+    if ! grep -q "^adu:" /etc/passwd 2>/dev/null; then
+        log_error "User 'adu' (UID 800) does not exist"
+        log_error "Required: RDEPENDS on azure-device-update"
+        create_diagnostic_snapshot
+        return $ERR_USER_MISSING
+    fi
+    
+    if ! grep -q "^adu:" /etc/group 2>/dev/null; then
+        log_error "Group 'adu' (GID 800) does not exist"
+        create_diagnostic_snapshot
+        return $ERR_USER_MISSING
+    fi
+    
+    log_info "Pre-flight: adu:adu user/group verified (UID:GID 800:800)"
+    
+    # Check and fix group memberships if 'do' user/group exists
+    if grep -q "^do:" /etc/passwd 2>/dev/null && grep -q "^do:" /etc/group 2>/dev/null; then
+        log_info "Pre-flight: Checking group memberships for adu and do users..."
+        
+        # Check if adu is member of do group
+        if ! id -nG adu 2>/dev/null | grep -qw do; then
+            log_warn "adu user is not member of 'do' group - fixing..."
+            if usermod -a -G do adu 2>/dev/null; then
+                log_info "✓ Added adu to 'do' group"
+            else
+                log_error "Failed to add adu to 'do' group"
+                return $ERR_USER_MISSING
+            fi
+        else
+            log_info "✓ adu is member of 'do' group"
+        fi
+        
+        # Check if do is member of adu group
+        if ! id -nG do 2>/dev/null | grep -qw adu; then
+            log_warn "do user is not member of 'adu' group - fixing..."
+            if usermod -a -G adu do 2>/dev/null; then
+                log_info "✓ Added do to 'adu' group"
+            else
+                log_error "Failed to add do to 'adu' group"
+                return $ERR_USER_MISSING
+            fi
+        else
+            log_info "✓ do is member of 'adu' group"
+        fi
+    else
+        log_info "Pre-flight: do user/group not present (delivery optimization not installed)"
+    fi
+    
+    return 0
+}
+
+# Safe ownership change with verification
+safe_chown() {
+    local owner="$1"
+    local path="$2"
+    
+    if ! chown "$owner" "$path" 2>/dev/null; then
+        log_error "Failed to chown $owner $path"
+        return $ERR_CHOWN_FAILED
+    fi
+    
+    # Verify it worked - compare both name and numeric formats
+    local actual_owner_name=$(stat -c '%U:%G' "$path" 2>/dev/null)
+    local actual_owner_numeric=$(stat -c '%u:%g' "$path" 2>/dev/null)
+    
+    # Check if either format matches (supports both "adu:adu" and "800:800")
+    if [ "$actual_owner_name" != "$owner" ] && [ "$actual_owner_numeric" != "$owner" ]; then
+        log_warn "chown reported success but ownership mismatch: expected=$owner actual=$actual_owner_name($actual_owner_numeric) path=$path"
+        return $ERR_CHOWN_FAILED
+    fi
+    
+    return 0
+}
+
+# Safe directory creation with verification
+safe_mkdir() {
+    local dir="$1"
+    
+    if ! mkdir -p "$dir" 2>/dev/null; then
+        log_error "Failed to create directory: $dir"
+        return $ERR_MKDIR_FAILED
+    fi
+    
+    if [ ! -d "$dir" ]; then
+        log_error "mkdir reported success but directory doesn't exist: $dir"
+        return $ERR_MKDIR_FAILED
+    fi
+    
+    return 0
+}
+
+# =========================================================================
+# Helper Functions
+# =========================================================================
+
+# Check if this is first boot (bootstrap phase)
+is_first_boot() {
+    [ ! -f "$VERSION_FILE" ]
+}
+
+# Get current setup version from partition
+get_current_version() {
+    if [ -f "$VERSION_FILE" ]; then
+        cat "$VERSION_FILE"
+    else
+        echo "0.0"
+    fi
+}
+
+# Update version file
+update_version() {
+    if echo "$SCRIPT_VERSION" > "$VERSION_FILE" 2>/dev/null; then
+        chmod 0644 "$VERSION_FILE" 2>/dev/null || log_warn "Could not chmod version file"
+        log_info "✓ Updated version marker to $SCRIPT_VERSION"
+        return 0
+    else
+        log_error "Failed to write version file: $VERSION_FILE"
+        return 1
+    fi
+}
+
+# =========================================================================
+# Phase 1: Bootstrap (First Boot Only)
+# =========================================================================
+bootstrap_directories() {
+    log_info "PHASE 1: Bootstrapping ADU directory structure (first boot)"
+    
+    # Set ownership on /adu mount point (generic requirement for all ADU devices)
+    log_info "Setting /adu mount point ownership..."
+    if ! safe_chown "800:800" /adu; then
+        log_error "Failed to set /adu ownership to 800:800"
+        return $ERR_CHOWN_FAILED
+    fi
+    
+    if ! chmod 770 /adu 2>/dev/null; then
+        log_error "Failed to chmod 770 /adu"
+        return $ERR_CHOWN_FAILED
+    fi
+    log_info "✓ /adu mount point: adu:adu (800:800) with mode 770"
+    
+    # Create directory structure on the mounted /adu partition
+    log_info "Creating directory structure..."
+    for dir in /adu/conf /adu/logs /adu/data/downloads /adu/data/extensions /adu/data/states /adu/data/sdc /adu/data/api /adu/tools; do
+        if ! safe_mkdir "$dir"; then
+            log_error "Failed to create $dir"
+            return $ERR_MKDIR_FAILED
+        fi
+    done
+    log_info "✓ Created directories: conf, logs, data/{downloads,extensions,states,sdc,api}, tools"
+    
+    # Set ownership and permissions with verification
+    log_info "Setting directory ownership and permissions..."
+    
+    # /adu/conf - Configuration files, readable by adu group
+    if ! safe_chown "adu:adu" /adu/conf || ! chmod 0750 /adu/conf; then
+        log_error "Failed to set ownership on /adu/conf"
+        return $ERR_CHOWN_FAILED
+    fi
+    log_info "✓ /adu/conf: adu:adu (750)"
+    
+    # /adu/logs - Log files, writable by adu user
+    if ! safe_chown "adu:adu" /adu/logs || ! chmod 0774 /adu/logs; then
+        log_error "Failed to set ownership on /adu/logs"
+        return $ERR_CHOWN_FAILED
+    fi
+    log_info "✓ /adu/logs: adu:adu (774)"
+    
+    # Create symlink /var/log/adu -> /adu/logs for compatibility
+    # Remove old directory or broken symlink if it exists
+    if [ -e /var/log/adu ] && [ ! -L /var/log/adu ]; then
+        log_warn "Found /var/log/adu as directory - removing to create symlink"
+        rm -rf /var/log/adu 2>/dev/null || log_error "Failed to remove /var/log/adu directory"
+    fi
+    if [ ! -e /var/log/adu ]; then
+        if ln -sf /adu/logs /var/log/adu 2>/dev/null; then
+            log_info "✓ Created symlink: /var/log/adu -> /adu/logs"
+        else
+            log_error "Failed to create symlink /var/log/adu -> /adu/logs"
+            return $ERR_MKDIR_FAILED
+        fi
+    else
+        log_info "  Symlink already exists: /var/log/adu -> /adu/logs"
+    fi
+    
+    # Create symlink /etc/adu -> /adu/conf for compatibility
+    # Remove old directory or broken symlink if it exists
+    if [ -e /etc/adu ] && [ ! -L /etc/adu ]; then
+        log_warn "Found /etc/adu as directory - removing to create symlink"
+        rm -rf /etc/adu 2>/dev/null || log_error "Failed to remove /etc/adu directory"
+    fi
+    if [ ! -e /etc/adu ]; then
+        if ln -sf /adu/conf /etc/adu 2>/dev/null; then
+            log_info "✓ Created symlink: /etc/adu -> /adu/conf"
+        else
+            log_error "Failed to create symlink /etc/adu -> /adu/conf"
+            return $ERR_MKDIR_FAILED
+        fi
+    else
+        log_info "  Symlink already exists: /etc/adu -> /adu/conf"
+    fi
+    
+    # /adu/data - Parent directory for persistent data
+    if ! safe_chown "adu:adu" /adu/data || ! chmod 0770 /adu/data; then
+        log_error "Failed to set ownership on /adu/data"
+        return $ERR_CHOWN_FAILED
+    fi
+    log_info "✓ /adu/data: adu:adu (770)"
+    
+    # Set ownership and permissions for /adu/data subdirectories
+    local data_subdirs=(
+        "downloads:Download cache (bind mount target for /var/lib/adu/downloads)"
+        "extensions:Extensions cache (bind mount target for /var/lib/adu/extensions)"
+        "states:State persistence (bind mount target for /var/lib/adu/states)"
+        "sdc:Delta source cache (bind mount target for /var/lib/adu/sdc) - used by microsoft-delta-download-handler"
+        "api:API FIFOs (bind mount target for /var/lib/adu/api) - for apireq.fifo"
+    )
+    
+    for subdir_info in "${data_subdirs[@]}"; do
+        local subdir="${subdir_info%%:*}"
+        local description="${subdir_info#*:}"
+        local full_path="/adu/data/${subdir}"
+        
+        if ! safe_chown "adu:adu" "$full_path" || ! chmod 0770 "$full_path"; then
+            log_error "Failed to set ownership on $full_path"
+            return $ERR_CHOWN_FAILED
+        fi
+        log_info "✓ /adu/data/${subdir}: adu:adu (770) - ${description}"
+    done
+    
+    # /adu/tools - Utility scripts, readable by all
+    if ! safe_chown "root:root" /adu/tools || ! chmod 0755 /adu/tools; then
+        log_error "Failed to set ownership on /adu/tools"
+        return $ERR_CHOWN_FAILED
+    fi
+    log_info "✓ /adu/tools: root:root (755)"
+    log_info "  Note: User tools are in /usr/sbin/ (adu-wifi-setup.sh, adu-wifi-diagnostics.sh)"
+    log_info "  Documentation is in /usr/share/doc/adu/"
+    
+    # Copy configuration templates (only if they don't exist)
+    log_info "Installing configuration templates..."
+    local template_count=0
+    if [ -d "$TEMPLATE_DIR" ]; then
+        for template in "$TEMPLATE_DIR"/*; do
+            if [ -f "$template" ]; then
+                filename=$(basename "$template")
+                target="/adu/conf/$filename"
+                
+                if [ ! -f "$target" ]; then
+                    if cp "$template" "$target" 2>/dev/null; then
+                        safe_chown "adu:adu" "$target" || log_warn "Could not set ownership on $target"
+                        chmod 0664 "$target" 2>/dev/null || log_warn "Could not chmod $target"
+                        log_info "✓ Installed template: $filename"
+                        template_count=$((template_count + 1))
+                    else
+                        log_error "Failed to copy template: $filename"
+                        return $ERR_TEMPLATE_FAILED
+                    fi
+                else
+                    log_info "  Template already exists: $filename"
+                fi
+            fi
+        done
+        log_info "✓ Installed $template_count configuration template(s)"
+    else
+        log_warn "Template directory not found: $TEMPLATE_DIR (continuing anyway)"
+    fi
+    
+    # Write version marker
+    if ! update_version; then
+        log_error "Failed to write version marker"
+        return 1
+    fi
+    
+    log_info "✓ Bootstrap complete - ADU partition ready for first use"
+    return 0
+}
+
+# =========================================================================
+# Phase 2: Verify (Every Boot)
+# =========================================================================
+verify_structure() {
+    log_info "PHASE 2: Verifying ADU directory structure"
+    
+    # Check if critical directories exist
+    local needs_repair=0
+    
+    for dir in /adu/conf /adu/logs /adu/data/downloads /adu/data/extensions /adu/data/states /adu/data/sdc /adu/data/api /adu/tools; do
+        if [ ! -d "$dir" ]; then
+            log_warn "Missing directory: $dir"
+            needs_repair=1
+        fi
+    done
+    
+    # Check ownership of critical directories (after A/B updates they might be wrong)
+    # /adu/conf must be adu:adu (uid 800, gid 800)
+    if [ -d /adu/conf ]; then
+        local conf_owner=$(stat -c '%u:%g' /adu/conf 2>/dev/null)
+        if [ "$conf_owner" != "800:800" ]; then
+            log_warn "/adu/conf has wrong ownership: $conf_owner (should be 800:800)"
+            needs_repair=1
+        fi
+    fi
+    
+    # Check if symlink exists and points to correct location
+    if [ ! -L /var/log/adu ]; then
+        log_warn "Missing or incorrect symlink: /var/log/adu"
+        needs_repair=1
+    elif [ "$(readlink /var/log/adu)" != "/adu/logs" ]; then
+        log_warn "Symlink /var/log/adu points to wrong location: $(readlink /var/log/adu)"
+        needs_repair=1
+    fi
+    
+    if [ $needs_repair -eq 1 ]; then
+        log_warn "Directory structure incomplete - triggering repair"
+        return 1
+    fi
+    
+    log_info "Directory structure verified"
+    return 0
+}
+
+# =========================================================================
+# Phase 3: Migrate (Version Changes)
+# =========================================================================
+migrate_configuration() {
+    local current_version=$(get_current_version)
+    
+    if [ "$current_version" = "$SCRIPT_VERSION" ]; then
+        log_info "PHASE 3: No migration needed (version $SCRIPT_VERSION)"
+        return 0
+    fi
+    
+    log_info "PHASE 3: Migrating from version $current_version to $SCRIPT_VERSION"
+    
+    # Future migrations can be added here based on version comparisons
+    # Example:
+    # if [ "$current_version" = "1.0" ] && [ "$SCRIPT_VERSION" = "1.1" ]; then
+    #     # Add new directory for version 1.1
+    #     mkdir -p /adu/new-feature
+    #     chown adu:adu /adu/new-feature
+    # fi
+    
+    # Update templates if new versions available (but preserve user changes)
+    if [ -d "$TEMPLATE_DIR" ]; then
+        for template in "$TEMPLATE_DIR"/*; do
+            if [ -f "$template" ]; then
+                filename=$(basename "$template")
+                target="/adu/conf/$filename"
+                
+                # Only copy if target doesn't exist (preserve user modifications)
+                if [ ! -f "$target" ]; then
+                    cp "$template" "$target"
+                    chown adu:adu "$target"
+                    chmod 0664 "$target"
+                    log_info "Installed new template: $filename"
+                fi
+            fi
+        done
+    fi
+    
+    update_version
+    log_info "Migration complete"
+    return 0
+}
+
+# =========================================================================
+# Phase 4: Repair (Fix Corruption)
+# =========================================================================
+repair_structure() {
+    log_info "PHASE 4: Repairing ADU directory structure"
+    
+    local repair_failed=0
+    
+    # Fix mount point ownership first (idempotent)
+    if ! safe_chown "adu:adu" /adu || ! chmod 770 /adu 2>/dev/null; then
+        log_error "Failed to fix /adu ownership"
+        repair_failed=1
+    else
+        log_info "✓ Fixed /adu mount point ownership"
+    fi
+    
+    # Recreate missing directories
+    for dir in /adu/conf /adu/logs /adu/data/downloads /adu/data/extensions /adu/data/states /adu/data/sdc /adu/data/api /adu/tools; do
+        if ! safe_mkdir "$dir"; then
+            log_error "Failed to recreate $dir"
+            repair_failed=1
+        fi
+    done
+    
+    # Fix ownership and permissions (idempotent)
+    safe_chown "adu:adu" /adu/conf && chmod 0750 /adu/conf 2>/dev/null || repair_failed=1
+    safe_chown "adu:adu" /adu/logs && chmod 0774 /adu/logs 2>/dev/null || repair_failed=1
+    safe_chown "adu:adu" /adu/data 2>/dev/null || repair_failed=1
+    safe_chown "adu:adu" /adu/data/downloads && chmod 0770 /adu/data/downloads 2>/dev/null || repair_failed=1
+    safe_chown "adu:adu" /adu/data/extensions && chmod 0770 /adu/data/extensions 2>/dev/null || repair_failed=1
+    safe_chown "adu:adu" /adu/data/states && chmod 0770 /adu/data/states 2>/dev/null || repair_failed=1
+    safe_chown "adu:adu" /adu/data/sdc && chmod 0770 /adu/data/sdc 2>/dev/null || repair_failed=1
+    safe_chown "adu:adu" /adu/data/api && chmod 0770 /adu/data/api 2>/dev/null || repair_failed=1
+    safe_chown "root:root" /adu/tools && chmod 0755 /adu/tools 2>/dev/null || repair_failed=1
+    
+    # Fix symlink /var/log/adu -> /adu/logs
+    if [ -e /var/log/adu ] && [ ! -L /var/log/adu ]; then
+        log_warn "Removing /var/log/adu directory to create symlink"
+        rm -rf /var/log/adu 2>/dev/null || {
+            log_error "Failed to remove /var/log/adu directory"
+            repair_failed=1
+        }
+    fi
+    if [ ! -e /var/log/adu ]; then
+        if ln -sf /adu/logs /var/log/adu 2>/dev/null; then
+            log_info "✓ Created symlink: /var/log/adu -> /adu/logs"
+        else
+            log_error "Failed to create symlink /var/log/adu"
+            repair_failed=1
+        fi
+    fi
+    
+    if [ $repair_failed -eq 0 ]; then
+        log_info "✓ Repair complete - all structures restored"
+        return 0
+    else
+        log_error "Repair completed with errors - see logs above"
+        return 1
+    fi
+}
+
+# =========================================================================
+# Main Execution
+# =========================================================================
+main() {
+    local exit_code=0
+    
+    # Initialize diagnostic logging first
+    init_fallback_logging
+    
+    log_info "========================================"
+    log_info "ADU Out-of-Box Experience v${SCRIPT_VERSION}"
+    log_info "========================================"
+    
+    # Pre-flight checks (critical - exit if these fail)
+    log_info "Running pre-flight checks..."
+    
+    if ! check_adu_mount; then
+        log_error "FATAL: /adu partition check failed"
+        log_error "This is a critical error - ADU cannot function without /adu partition"
+        log_error "Debug: Check systemd service 'adu.mount' and /etc/fstab"
+        create_diagnostic_snapshot
+        exit $ERR_MOUNT_MISSING
+    fi
+    
+    if ! check_users; then
+        log_error "FATAL: Required users/groups missing"
+        log_error "This usually means azure-device-update package hasn't run postinst yet"
+        log_error "Debug: Check if azure-device-update is installed: opkg list-installed | grep azure-device-update"
+        create_diagnostic_snapshot
+        exit $ERR_USER_MISSING
+    fi
+    
+    log_info "✓ Pre-flight checks passed"
+    log_info ""
+    
+    # Phase 1: Bootstrap (first boot only)
+    if is_first_boot; then
+        log_info "Detected FIRST BOOT - running bootstrap"
+        if bootstrap_directories; then
+            log_info ""
+            log_info "========================================" 
+            log_info "✓ SUCCESS: First-boot setup complete"
+            log_info "Device is ready for ADU operations"
+            log_info "========================================"
+            create_diagnostic_snapshot "$FALLBACK_LOG_DIR/oobe-success.txt"
+            exit 0
+        else
+            exit_code=$?
+            log_error ""
+            log_error "========================================"
+            log_error "✗ FAILED: Bootstrap phase failed"
+            log_error "========================================"
+            create_diagnostic_snapshot
+            exit $exit_code
+        fi
+    fi
+    
+    # Phase 2: Verify structure
+    log_info "Running verification phase..."
+    if ! verify_structure; then
+        log_warn "Verification failed - initiating repair"
+        
+        # Phase 4: Repair if verification failed
+        if ! repair_structure; then
+            log_error "Repair phase failed"
+            create_diagnostic_snapshot
+            exit_code=1
+        else
+            log_info "✓ Repair successful"
+        fi
+    else
+        log_info "✓ Verification passed"
+    fi
+    
+    # Phase 3: Migrate if version changed
+    if ! migrate_configuration; then
+        log_error "Migration phase failed"
+        create_diagnostic_snapshot
+        exit_code=1
+    fi
+    
+    if [ $exit_code -eq 0 ]; then
+        log_info ""
+        log_info "========================================"
+        log_info "✓ SUCCESS: ADU setup complete"
+        log_info "Device verified and ready"
+        log_info "========================================"
+    else
+        log_error ""
+        log_error "========================================"
+        log_error "✗ FAILED: ADU setup completed with errors"
+        log_error "Check logs: journalctl -u adu-oobe.service"
+        log_error "Check diagnostics: cat $FALLBACK_LOG"
+        log_error "========================================"
+        create_diagnostic_snapshot
+    fi
+    
+    exit $exit_code
+}
+
+# Run main function
+main

--- a/recipes-azure-device-update/adu-filesystem-layout/adu-filesystem-layout_1.0.bb
+++ b/recipes-azure-device-update/adu-filesystem-layout/adu-filesystem-layout_1.0.bb
@@ -1,0 +1,44 @@
+# Recipe: adu-filesystem-layout
+# Purpose: Minimal /adu partition structure setup (generic, platform-independent)
+# Scope: ONLY manages /adu/* directories - does NOT touch /var/lib/adu, /var/log/adu, /etc/adu
+#        Persistence strategy (symlinks vs overlayfs) handled by separate recipes
+
+SUMMARY = "ADU Filesystem Layout - /adu partition structure"
+DESCRIPTION = "Creates and manages directory structure on /adu partition. \
+               Does not implement persistence strategy - that's handled by \
+               adu-persistence-symlinks or adu-persistent-overlay recipes."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://setup-adu-filesystem.sh \
+    file://adu-filesystem-layout.service \
+"
+
+S = "${WORKDIR}"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "adu-filesystem-layout.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+# Runtime dependencies
+RDEPENDS:${PN} = "azure-device-update bash"
+
+do_install() {
+    # Install setup script
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/setup-adu-filesystem.sh ${D}${sbindir}/
+    
+    # Install systemd service
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/adu-filesystem-layout.service ${D}${systemd_system_unitdir}/
+}
+
+FILES:${PN} = " \
+    ${sbindir}/setup-adu-filesystem.sh \
+    ${systemd_system_unitdir}/adu-filesystem-layout.service \
+"
+
+# This recipe provides the base filesystem layout
+PROVIDES = "adu-filesystem-base"

--- a/recipes-azure-device-update/adu-filesystem-layout/files/adu-filesystem-layout.service
+++ b/recipes-azure-device-update/adu-filesystem-layout/files/adu-filesystem-layout.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=ADU Filesystem Layout - /adu partition structure setup
+Documentation=https://github.com/Azure/iot-hub-device-update
+After=adu.mount
+Requires=adu.mount
+Before=adu-persistent-overlay.service adu-persistence-symlinks.service deviceupdate-agent.service
+ConditionPathIsMountPoint=/adu
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/setup-adu-filesystem.sh
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening
+PrivateTmp=yes
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/adu
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-azure-device-update/adu-filesystem-layout/files/setup-adu-filesystem.sh
+++ b/recipes-azure-device-update/adu-filesystem-layout/files/setup-adu-filesystem.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# ADU Filesystem Layout Setup
+# Purpose: Create and maintain /adu partition directory structure
+# Scope: ONLY manages /adu/* - does NOT create symlinks to /var/* or /etc/*
+# Version: 1.0
+
+set -e
+
+VERSION_FILE="/adu/.filesystem-layout-version"
+SCRIPT_VERSION="1.0"
+LOG_PREFIX="[ADU-FS-LAYOUT]"
+
+log_info() {
+    echo "$LOG_PREFIX INFO: $*"
+    logger -t adu-filesystem-layout -p user.info "$*"
+}
+
+log_error() {
+    echo "$LOG_PREFIX ERROR: $*" >&2
+    logger -t adu-filesystem-layout -p user.err "$*"
+}
+
+# Check if /adu is mounted and writable
+check_adu_mount() {
+    if [ ! -d /adu ]; then
+        log_error "/adu directory does not exist"
+        return 1
+    fi
+    
+    if ! mount | grep -q '/adu'; then
+        log_error "/adu is not mounted"
+        return 1
+    fi
+    
+    if ! touch /adu/.write-test 2>/dev/null; then
+        log_error "/adu is not writable"
+        return 1
+    fi
+    rm -f /adu/.write-test
+    
+    log_info "/adu mount verified"
+    return 0
+}
+
+# Create /adu partition directory structure
+setup_directories() {
+    log_info "Creating /adu directory structure..."
+    
+    # Core directories
+    mkdir -p /adu/conf
+    mkdir -p /adu/logs
+    mkdir -p /adu/data/downloads
+    mkdir -p /adu/data/extensions/sources
+    mkdir -p /adu/data/extensions/component_enumerator
+    mkdir -p /adu/data/extensions/content_downloader
+    mkdir -p /adu/data/extensions/update_content_handlers
+    mkdir -p /adu/data/extensions/download_handlers
+    mkdir -p /adu/data/states
+    mkdir -p /adu/tools
+    
+    # Optional directories for persistence strategies
+    mkdir -p /adu/overlay
+    mkdir -p /adu/work
+    mkdir -p /adu/system
+    mkdir -p /adu/.backups
+    
+    log_info "✓ Created directory structure"
+}
+
+# Set ownership and permissions
+set_permissions() {
+    log_info "Setting ownership and permissions..."
+    
+    # /adu mount point
+    chown adu:adu /adu 2>/dev/null || log_error "Failed to chown /adu (adu user may not exist yet)"
+    chmod 0770 /adu
+    
+    # /adu/conf - Configuration files (readable by adu group)
+    chown -R adu:adu /adu/conf 2>/dev/null || true
+    chmod 0750 /adu/conf
+    
+    # /adu/logs - Log files (writable by adu user)
+    chown -R adu:adu /adu/logs 2>/dev/null || true
+    chmod 0774 /adu/logs
+    
+    # /adu/data - ADU data (downloads, extensions, states)
+    chown -R adu:adu /adu/data 2>/dev/null || true
+    chmod 0770 /adu/data
+    find /adu/data -type d -exec chmod 0770 {} \; 2>/dev/null || true
+    
+    # /adu/tools - Root-owned tools
+    chown root:root /adu/tools
+    chmod 0755 /adu/tools
+    
+    # Persistence strategy directories (owned by adu for flexibility)
+    chown adu:adu /adu/overlay /adu/work /adu/system /adu/.backups 2>/dev/null || true
+    chmod 0770 /adu/overlay /adu/work /adu/system /adu/.backups 2>/dev/null || true
+    
+    log_info "✓ Set ownership and permissions"
+}
+
+# Verify directory structure
+verify_structure() {
+    log_info "Verifying directory structure..."
+    
+    local failed=0
+    local required_dirs=(
+        "/adu/conf"
+        "/adu/logs"
+        "/adu/data/downloads"
+        "/adu/data/extensions"
+        "/adu/data/states"
+        "/adu/tools"
+    )
+    
+    for dir in "${required_dirs[@]}"; do
+        if [ ! -d "$dir" ]; then
+            log_error "Required directory missing: $dir"
+            failed=1
+        fi
+    done
+    
+    if [ $failed -eq 1 ]; then
+        log_error "Directory structure verification failed"
+        return 1
+    fi
+    
+    log_info "✓ Directory structure verified"
+    return 0
+}
+
+# Get current version
+get_current_version() {
+    if [ -f "$VERSION_FILE" ]; then
+        cat "$VERSION_FILE"
+    else
+        echo "0.0"
+    fi
+}
+
+# Update version file
+update_version() {
+    echo "$SCRIPT_VERSION" > "$VERSION_FILE"
+    chmod 0644 "$VERSION_FILE"
+    log_info "✓ Updated version marker to $SCRIPT_VERSION"
+}
+
+# Main execution
+main() {
+    log_info "=== ADU Filesystem Layout Setup v${SCRIPT_VERSION} ==="
+    
+    # Pre-flight checks
+    if ! check_adu_mount; then
+        log_error "Pre-flight check failed - /adu not properly mounted"
+        exit 1
+    fi
+    
+    current_version=$(get_current_version)
+    log_info "Current version: $current_version, Script version: $SCRIPT_VERSION"
+    
+    if [ "$current_version" = "0.0" ]; then
+        # First boot - full setup
+        log_info "First boot detected - performing full setup"
+        setup_directories
+        set_permissions
+        verify_structure || exit 1
+        update_version
+        log_info "✓ First boot setup completed successfully"
+        
+    elif [ "$current_version" != "$SCRIPT_VERSION" ]; then
+        # Version upgrade - verify and repair
+        log_info "Version upgrade detected ($current_version → $SCRIPT_VERSION)"
+        setup_directories  # Idempotent - creates missing dirs
+        set_permissions    # Idempotent - fixes permissions
+        verify_structure || exit 1
+        update_version
+        log_info "✓ Upgrade completed successfully"
+        
+    else
+        # Already set up - quick verification
+        log_info "Already set up (v${SCRIPT_VERSION}) - performing quick verification"
+        if ! verify_structure; then
+            log_info "Verification failed - attempting repair"
+            setup_directories
+            set_permissions
+            verify_structure || exit 1
+            log_info "✓ Repair completed successfully"
+        else
+            log_info "✓ Verification passed - no action needed"
+        fi
+    fi
+    
+    log_info "=== ADU Filesystem Layout Setup Complete ==="
+    exit 0
+}
+
+main "$@"

--- a/recipes-azure-device-update/adu-persistence-symlinks/adu-persistence-symlinks_1.0.bb
+++ b/recipes-azure-device-update/adu-persistence-symlinks/adu-persistence-symlinks_1.0.bb
@@ -1,0 +1,48 @@
+# Recipe: adu-persistence-symlinks
+# Purpose: Simple symlink-based persistence strategy for ADU directories
+# Strategy: Create symlinks /var/lib/adu → /adu/data, /var/log/adu → /adu/logs, /etc/adu → /adu/conf
+# Use Case: Simple A/B updates without overlayfs complexity
+
+SUMMARY = "ADU Persistence Strategy - Symlinks"
+DESCRIPTION = "Implements symlink-based persistence for ADU directories. \
+               Symlinks are created from /var/lib/adu, /var/log/adu, /etc/adu to /adu partition. \
+               This is the simpler persistence strategy, suitable for basic A/B updates."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://setup-adu-symlinks.sh \
+    file://adu-persistence-symlinks.service \
+"
+
+S = "${WORKDIR}"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "adu-persistence-symlinks.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+# Dependencies
+RDEPENDS:${PN} = "adu-filesystem-layout"
+
+# Conflicts with overlayfs strategy
+RCONFLICTS:${PN} = "adu-persistent-overlay"
+
+do_install() {
+    # Install setup script
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/setup-adu-symlinks.sh ${D}${sbindir}/
+    
+    # Install systemd service
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/adu-persistence-symlinks.service ${D}${systemd_system_unitdir}/
+}
+
+FILES:${PN} = " \
+    ${sbindir}/setup-adu-symlinks.sh \
+    ${systemd_system_unitdir}/adu-persistence-symlinks.service \
+"
+
+# This recipe provides ADU persistence strategy
+PROVIDES = "adu-persistence-strategy"
+RPROVIDES:${PN} = "adu-persistence-strategy"

--- a/recipes-azure-device-update/adu-persistence-symlinks/files/adu-persistence-symlinks.service
+++ b/recipes-azure-device-update/adu-persistence-symlinks/files/adu-persistence-symlinks.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=ADU Persistence Strategy - Symlinks
+Documentation=https://github.com/Azure/iot-hub-device-update
+After=adu-filesystem-layout.service
+Requires=adu-filesystem-layout.service
+Before=deviceupdate-agent.service
+ConditionPathIsMountPoint=/adu
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/setup-adu-symlinks.sh
+RemainAfterExit=yes
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening
+PrivateTmp=yes
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/adu /var/lib /var/log /etc
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-azure-device-update/adu-persistence-symlinks/files/setup-adu-symlinks.sh
+++ b/recipes-azure-device-update/adu-persistence-symlinks/files/setup-adu-symlinks.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# ADU Persistence Strategy - Symlinks
+# Purpose: Create symlinks from /var/lib/adu, /var/log/adu, /etc/adu to /adu partition
+# Version: 1.0
+
+set -e
+
+VERSION_FILE="/adu/.symlinks-persistence-version"
+SCRIPT_VERSION="1.0"
+LOG_PREFIX="[ADU-SYMLINKS]"
+
+log_info() {
+    echo "$LOG_PREFIX INFO: $*"
+    logger -t adu-persistence-symlinks -p user.info "$*"
+}
+
+log_warn() {
+    echo "$LOG_PREFIX WARNING: $*" >&2
+    logger -t adu-persistence-symlinks -p user.warning "$*"
+}
+
+log_error() {
+    echo "$LOG_PREFIX ERROR: $*" >&2
+    logger -t adu-persistence-symlinks -p user.err "$*"
+}
+
+# Create or verify symlink
+create_symlink() {
+    local target="$1"
+    local link="$2"
+    local description="$3"
+    
+    # If link already exists as correct symlink, nothing to do
+    if [ -L "$link" ] && [ "$(readlink "$link")" = "$target" ]; then
+        log_info "✓ $description: $link → $target (already exists)"
+        return 0
+    fi
+    
+    # If link exists but is wrong (directory or wrong symlink), migrate
+    if [ -e "$link" ] || [ -L "$link" ]; then
+        if [ -d "$link" ] && [ ! -L "$link" ]; then
+            log_warn "$link exists as directory - migrating content to $target"
+            # Copy content to target location
+            cp -a "$link/." "$target/" 2>/dev/null || true
+            # Remove original directory
+            rm -rf "$link"
+        elif [ -L "$link" ]; then
+            log_warn "$link is symlink to wrong target - updating"
+            rm -f "$link"
+        else
+            log_warn "$link exists as file - backing up and replacing"
+            mv "$link" "${link}.backup"
+        fi
+    fi
+    
+    # Create parent directory if needed
+    mkdir -p "$(dirname "$link")"
+    
+    # Create the symlink
+    ln -sf "$target" "$link"
+    
+    # Set ownership (symlinks are lrwxrwxrwx, but we set for reference)
+    chown -h adu:adu "$link" 2>/dev/null || true
+    
+    log_info "✓ $description: Created $link → $target"
+    return 0
+}
+
+# Setup all symlinks
+setup_symlinks() {
+    log_info "Creating ADU persistence symlinks..."
+    
+    # /var/lib/adu → /adu/data (ADU data: downloads, extensions, states)
+    create_symlink "/adu/data" "/var/lib/adu" "ADU data directory"
+    
+    # /var/log/adu → /adu/logs (ADU logs)
+    create_symlink "/adu/logs" "/var/log/adu" "ADU log directory"
+    
+    # /etc/adu → /adu/conf (ADU configuration)
+    create_symlink "/adu/conf" "/etc/adu" "ADU config directory"
+    
+    log_info "✓ All symlinks created successfully"
+}
+
+# Verify symlinks
+verify_symlinks() {
+    log_info "Verifying symlinks..."
+    
+    local failed=0
+    
+    # Check /var/lib/adu → /adu/data
+    if [ ! -L "/var/lib/adu" ] || [ "$(readlink /var/lib/adu)" != "/adu/data" ]; then
+        log_error "/var/lib/adu symlink incorrect"
+        failed=1
+    fi
+    
+    # Check /var/log/adu → /adu/logs
+    if [ ! -L "/var/log/adu" ] || [ "$(readlink /var/log/adu)" != "/adu/logs" ]; then
+        log_error "/var/log/adu symlink incorrect"
+        failed=1
+    fi
+    
+    # Check /etc/adu → /adu/conf
+    if [ ! -L "/etc/adu" ] || [ "$(readlink /etc/adu)" != "/adu/conf" ]; then
+        log_error "/etc/adu symlink incorrect"
+        failed=1
+    fi
+    
+    if [ $failed -eq 1 ]; then
+        log_error "Symlink verification failed"
+        return 1
+    fi
+    
+    log_info "✓ All symlinks verified"
+    return 0
+}
+
+# Get current version
+get_current_version() {
+    if [ -f "$VERSION_FILE" ]; then
+        cat "$VERSION_FILE"
+    else
+        echo "0.0"
+    fi
+}
+
+# Update version file
+update_version() {
+    echo "$SCRIPT_VERSION" > "$VERSION_FILE"
+    chmod 0644 "$VERSION_FILE"
+    log_info "✓ Updated version marker to $SCRIPT_VERSION"
+}
+
+# Main execution
+main() {
+    log_info "=== ADU Symlinks Persistence Setup v${SCRIPT_VERSION} ==="
+    
+    # Verify /adu structure exists (created by adu-filesystem-layout)
+    if [ ! -d /adu/conf ] || [ ! -d /adu/logs ] || [ ! -d /adu/data ]; then
+        log_error "/adu structure incomplete - adu-filesystem-layout must run first"
+        exit 1
+    fi
+    
+    current_version=$(get_current_version)
+    log_info "Current version: $current_version, Script version: $SCRIPT_VERSION"
+    
+    if [ "$current_version" = "0.0" ]; then
+        # First boot - create symlinks
+        log_info "First boot detected - creating symlinks"
+        setup_symlinks
+        verify_symlinks || exit 1
+        update_version
+        log_info "✓ First boot setup completed successfully"
+        
+    elif [ "$current_version" != "$SCRIPT_VERSION" ]; then
+        # Version upgrade - verify and repair
+        log_info "Version upgrade detected ($current_version → $SCRIPT_VERSION)"
+        setup_symlinks  # Idempotent
+        verify_symlinks || exit 1
+        update_version
+        log_info "✓ Upgrade completed successfully"
+        
+    else
+        # Already set up - quick verification
+        log_info "Already set up (v${SCRIPT_VERSION}) - performing quick verification"
+        if ! verify_symlinks; then
+            log_info "Verification failed - attempting repair"
+            setup_symlinks
+            verify_symlinks || exit 1
+            log_info "✓ Repair completed successfully"
+        else
+            log_info "✓ Verification passed - no action needed"
+        fi
+    fi
+    
+    log_info "=== ADU Symlinks Persistence Setup Complete ==="
+    exit 0
+}
+
+main "$@"

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -29,11 +29,11 @@ ADU_GENERATION ?= "1"
 ADU_EMBED_TEST_ROOT_KEYS ?= "0"
 
 # For gen1, the release come out of develop branch, not main.
-ADU_GIT_BRANCH ?= "develop"
+ADU_GIT_BRANCH ?= "feature/vnext-delta"
 ADU_SRC_URI ?= "git://github.com/Azure/iot-hub-device-update"
 ADU_GIT_PROTOCOL ?= "https"
 SRC_URI = "${ADU_SRC_URI};protocol=${ADU_GIT_PROTOCOL};branch=${ADU_GIT_BRANCH}"
-ADU_GIT_COMMIT ?= "350a551dd9d3f5639eddceb75ef5b10e834865fe"
+ADU_GIT_COMMIT ?= "5b169864a9f6789368f0b701afb4df02018be677"
 # CMake build types: "Release" "RelWithDebInfo" "MinSizeRel"
 BUILD_TYPE ?= "Debug"
 

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -61,11 +61,6 @@ WITH_ADUC_TESTS ?= "0"
 # Set to "1" to always include Catch2, "0" to never include it, or leave unset to inherit from WITH_ADUC_TESTS
 WITH_ADUC_CATCH2_DEP ?= "${WITH_ADUC_TESTS}"
 
-# Setup NTP servers (and fallbacks) to sync the date+time and not fail when
-# verifying the TLS server ca cert due to "notBefore" property.
-# See do_install:append() below for where it installs timesyncd.conf
-SRC_URI += "file://timesyncd.conf"
-
 # Local source development mode
 python __anonymous() {
     import os
@@ -225,7 +220,8 @@ EXTRA_OECMAKE += "${@bb.utils.contains('ADU_GENERATION', '1', '-Dcpprestsdk_DIR=
 EXTRA_OECMAKE += "${@bb.utils.contains('ADU_EMBED_TEST_ROOT_KEYS', '1', '-DADUC_USE_TEST_ROOT_KEYS=true', '', d)}"
 EXTRA_OECMAKE += "${@bb.utils.contains('ADU_EMBED_TEST_ROOT_KEYS', '1', '-DADUC_ENABLE_E2E_TESTING=true', '', d)}"
 # Enable building unit tests with Catch2
-EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '1', '-DADUC_BUILD_UNIT_TESTS=ON', '-DADUC_BUILD_UNIT_TESTS=OFF', d)}"
+# Force disable unit tests - cross-compilation causes Catch2 test discovery to fail
+EXTRA_OECMAKE += "-DADUC_BUILD_UNIT_TESTS=OFF"
 # Enable delta handler build when delta updates are enabled
 EXTRA_OECMAKE += "${@bb.utils.contains('WITH_FEATURE_DELTA_UPDATE', '1', '-DADUC_BUILD_DELTA_HANDLER=ON', '', d)}"
 

--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -37,11 +37,22 @@ ADU_GIT_COMMIT ?= "350a551dd9d3f5639eddceb75ef5b10e834865fe"
 # CMake build types: "Release" "RelWithDebInfo" "MinSizeRel"
 BUILD_TYPE ?= "Debug"
 
+# Local source support for development
+# Enable: Set USE_LOCAL_ADU_SOURCE=1 and ensure it's passed through to BitBake:
+#   BB_ENV_PASSTHROUGH_ADDITIONS="USE_LOCAL_ADU_SOURCE ADU_LOCAL_SOURCE_DIR"
+# Override default path: export ADU_LOCAL_SOURCE_DIR=/custom/path
+# See layer README.md for usage examples
+ADU_LOCAL_SOURCE_DIR ?= "${TOPDIR}/../../../sources/iot-hub-device-update"
+
 #
 # Feature flags
 #
 # Include DeltaUpdate Processor libary
-WITH_FEATURE_DELTA_UPDATE ?= "0"
+WITH_FEATURE_DELTA_UPDATE ?= "1"
+
+# Use .NET-based diff generation tool (requires Mono runtime)
+# Set to "0" to use alternative diff tools (e.g., Python bsdiff)
+WITH_DOTNET_DIFFGEN_TOOL ?= "0"
 
 # Enable building unit tests (requires Catch2)
 WITH_ADUC_TESTS ?= "0"
@@ -54,6 +65,39 @@ WITH_ADUC_CATCH2_DEP ?= "${WITH_ADUC_TESTS}"
 # verifying the TLS server ca cert due to "notBefore" property.
 # See do_install:append() below for where it installs timesyncd.conf
 SRC_URI += "file://timesyncd.conf"
+
+# Local source development mode
+python __anonymous() {
+    import os
+    
+    use_local = d.getVar('USE_LOCAL_ADU_SOURCE')
+    local_src = d.getVar('ADU_LOCAL_SOURCE_DIR')
+    
+    if use_local == "1":
+        if local_src and os.path.exists(local_src):
+            bb.warn("=" * 60)
+            bb.warn("Using LOCAL ADU source from: %s" % local_src)
+            bb.warn("GitHub fetch: DISABLED")
+            bb.warn("Patches: NOT APPLIED (apply manually if needed)")
+            bb.warn("=" * 60)
+            
+            # Set EXTERNALSRC to use local directory
+            d.setVar('EXTERNALSRC', local_src)
+            d.setVar('EXTERNALSRC_BUILD', local_src + '/build-yocto')
+            
+            # Override S to point to EXTERNALSRC instead of ${WORKDIR}/git
+            d.setVar('S', local_src)
+            
+            # Disable fetch and unpack tasks (source already available)
+            d.setVarFlag('do_fetch', 'noexec', '1')
+            d.setVarFlag('do_unpack', 'noexec', '1')
+            d.setVarFlag('do_patch', 'noexec', '1')
+            
+            # Mark as externally provided
+            d.setVar('EXTERNALSRC_SYMLINKS', '')
+        else:
+            bb.fatal("USE_LOCAL_ADU_SOURCE=1 but directory not found: %s" % local_src)
+}
 
 # Handle override of default vars with those for Gen2
 python() {
@@ -129,6 +173,7 @@ DEPENDS = "deliveryoptimization-agent deliveryoptimization-sdk curl azure-iot-sd
 DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-sdk-for-cpp', '', d)}"
 DEPENDS += "${@bb.utils.contains('ADU_GENERATION', '2', 'mosquitto', '', d)}"
 DEPENDS += "${@bb.utils.contains('WITH_ADUC_CATCH2_DEP', '1', 'catch2', '', d)}"
+DEPENDS += "${@bb.utils.contains('WITH_FEATURE_DELTA_UPDATE', '1', 'iot-hub-device-update-delta-processor', '', d)}"
 
 # Append to the build-time dependencies as per differences between Gen1 and Gen2
 #
@@ -167,11 +212,8 @@ EXTRA_OECMAKE += "-DADUC_MODEL_FILE=${sysconfdir}/adu-model"
 EXTRA_OECMAKE += "-DADUC_VERSION_FILE=${sysconfdir}/adu-version"
 # Use zlog as the logging library.
 EXTRA_OECMAKE += "-DADUC_LOGGING_LIBRARY=zlog"
-# Change the log directory.
-EXTRA_OECMAKE += "-DADUC_LOG_FOLDER=/adu/logs"
 # Use /adu directory for configuration.
 # The /adu directory is on a seperate partition and is not updated during an OTA update.
-EXTRA_OECMAKE += "-DADUC_CONF_FOLDER=/adu"
 # Don't install/configure the daemon, another bitbake recipe will do that.
 EXTRA_OECMAKE += "-DADUC_INSTALL_DAEMON=OFF"
 # Using the installed DO SDK include files.
@@ -184,12 +226,17 @@ EXTRA_OECMAKE += "${@bb.utils.contains('ADU_EMBED_TEST_ROOT_KEYS', '1', '-DADUC_
 EXTRA_OECMAKE += "${@bb.utils.contains('ADU_EMBED_TEST_ROOT_KEYS', '1', '-DADUC_ENABLE_E2E_TESTING=true', '', d)}"
 # Enable building unit tests with Catch2
 EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '1', '-DADUC_BUILD_UNIT_TESTS=ON', '-DADUC_BUILD_UNIT_TESTS=OFF', d)}"
+# Enable delta handler build when delta updates are enabled
+EXTRA_OECMAKE += "${@bb.utils.contains('WITH_FEATURE_DELTA_UPDATE', '1', '-DADUC_BUILD_DELTA_HANDLER=ON', '', d)}"
 
 # Additional flags to completely disable all testing and test discovery  
 EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DBUILD_TESTING=OFF', '', d)}"
 EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DCATCH_BUILD_TESTING=OFF', '', d)}"
 EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DENABLE_TESTING=OFF', '', d)}"
 EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DCMAKE_DISABLE_TESTING=ON', '', d)}"
+EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DADUC_BUILD_UNIT_TESTS=OFF', '', d)}"
+# Disable automatic test discovery for Catch2 during cross-compilation
+EXTRA_OECMAKE += "-DCATCH_DISCOVER_TESTS_ADD_TARGET_IN_TEST_NAME=OFF"
 
 # RDEPENDS are the RUNTIME dependencies that must be installed on the target
 # system for the cuurent package to function correctly.
@@ -200,10 +247,11 @@ EXTRA_OECMAKE += "${@bb.utils.contains('WITH_ADUC_TESTS', '0', '-DCMAKE_DISABLE_
 # adu-log-dir - to create the temporary log directory in the image.
 # deliveryoptimization-agent-service - to install the delivery optimization agent for downloads.
 # curl - for running the diagnostics component, curl content downloader
-# azure-device-update-diffs - to include the recipe for github.com:azure/iot-hub-device-update-delta runtime shared lib for delta updates.
+# iot-hub-device-update-delta-processor - to include the runtime shared lib for delta updates.
 #
 RDEPENDS:${PN} += "bash swupdate  adu-pub-key adu-log-dir deliveryoptimization-agent-service curl openssl-bin nss ca-certificates"
-RDEPENDS:${PN} += "${@bb.utils.contains('WITH_FEATURE_DELTA_UPDATE', '1', 'azure-device-update-diffs', '', d)}"
+RDEPENDS:${PN} += "${@bb.utils.contains('WITH_DOTNET_DIFFGEN_TOOL', '1', 'iot-hub-device-update-delta-diff-generation', '', d)}"
+RDEPENDS:${PN} += "${@bb.utils.contains('WITH_FEATURE_DELTA_UPDATE', '1', 'iot-hub-device-update-delta-processor', '', d)}"
 
 ADUC_DATA_DIR ?= "/var/lib/adu"
 ADUC_EXTENSIONS_DIR ?= "${ADUC_DATA_DIR}/extensions"
@@ -244,10 +292,24 @@ USERADD_PARAM:${PN} = "\
 do_compile[depends] += "azure-iot-sdk-c:do_prepare_recipe_sysroot"
 do_compile[depends] += "${@bb.utils.contains('ADU_GENERATION', '1', 'azure-sdk-for-cpp:do_prepare_recipe_sysroot', '', d)}"
 
+# Run unit tests after compilation if enabled
+do_compile:append() {
+    if [ "${WITH_ADUC_TESTS}" = "1" ]; then
+        bbnote "========================================"
+        bbnote "Unit tests built successfully"
+        bbnote "========================================"
+        bbnote "NOTE: Test binaries compiled but NOT executed during cross-compilation"
+        bbnote "Test binaries will be available on target device in /usr/lib/adu/tests/"
+        bbnote "To run tests on device: /usr/lib/adu/tests/<test_name>"
+        bbnote "========================================"
+    else
+        bbnote "Unit tests disabled (WITH_ADUC_TESTS=${WITH_ADUC_TESTS})"
+    fi
+}
+
 do_install:append() {
     # Install timesyncd.conf to setup NTP to sync the time correctly.
     install -d ${D}${sysconfdir}/systemd
-    install -m 0644 ${WORKDIR}/timesyncd.conf ${D}${sysconfdir}/systemd/
 
     #create ADUC_DATA_DIR
     install -d ${D}${ADUC_DATA_DIR}
@@ -280,6 +342,11 @@ do_install:append() {
     chgrp ${ADUGROUP} ${D}${ADUC_UPDATE_CONTENT_HANDLER_EXTENSION_DIR}
     chmod 0770 ${D}${ADUC_UPDATE_CONTENT_HANDLER_EXTENSION_DIR}
 
+    #create ADUC_DOWNLOAD_HANDLER_EXTENSION_DIR
+    install -d ${D}${ADUC_DOWNLOAD_HANDLER_EXTENSION_DIR}
+    chgrp ${ADUGROUP} ${D}${ADUC_DOWNLOAD_HANDLER_EXTENSION_DIR}
+    chmod 0770 ${D}${ADUC_DOWNLOAD_HANDLER_EXTENSION_DIR}
+
     #create ADUC_DOWNLOADS_DIR
     install -d ${D}${ADUC_DOWNLOADS_DIR}
     chown ${ADUUSER}:${ADUGROUP} ${D}${ADUC_DOWNLOADS_DIR}
@@ -295,8 +362,13 @@ do_install:append() {
     chown ${ADUUSER}:${ADUGROUP} ${D}${ADUC_LOG_DIR}
     chmod 0774 ${D}${ADUC_LOG_DIR}
 
-    install -m 0550 ${S}/src/adu-shell/scripts/adu-swupdate.sh ${D}${bindir}
-    chown ${ADUUSER}:${ADUGROUP} ${D}${bindir}/adu-swupdate.sh
+    # Note: adu-swupdate.sh removed - microsoft/swupdate:1 deprecated
+    # Use microsoft/swupdate:2 with yocto-a-b-update.sh instead
+
+    # Install reboot wrapper script to /usr/lib/adu
+    install -d ${D}/usr/lib/adu
+    install -m 0755 ${S}/src/adu-shell/scripts/adu-reboot-wrapper.sh ${D}/usr/lib/adu/
+    chown root:${ADUGROUP} ${D}/usr/lib/adu/adu-reboot-wrapper.sh
 
     #set owner for adu-shell
     chmod 0550 ${D}${bindir}/adu-shell
@@ -304,6 +376,9 @@ do_install:append() {
 
     #set S UID for adu-shell
     chmod u+s ${D}${bindir}/adu-shell
+
+    # Remove systemd config files that should be owned by systemd package
+    rm -f ${D}/etc/systemd/timesyncd.conf
 }
 
 #We don't want the library file hashes to change between do_image -> do_package,
@@ -332,8 +407,8 @@ fakeroot python do_registerAgentExtensions() {
         # TODO: re-enable DO content downloader once available again upstream
         #register_content_downloader("{}/libdeliveryoptimization_content_downloader.so".format(extensionInstallDir), contentDownloaderRegistrationDirectory, workDir)
         register_content_downloader("{}/libcurl_content_downloader.so".format(extensionInstallDir), contentDownloaderRegistrationDirectory, workDir)
-        # TODO: re-enable delta here once patches for recipe is done
-        #register_download_handler("microsoft/delta:1", "{}/libmicrosoft_delta_download_handler.so".format(extensionInstallDir), downloadHandlerRegistrationDirectory, workDir)
+        # Register delta download handler for differential update support
+        register_download_handler("microsoft/delta:1", "{}/libmicrosoft_delta_download_handler.so".format(extensionInstallDir), downloadHandlerRegistrationDirectory, workDir)
 
     except Exception as ex:
         errorMessage = "Failed to create DU Agent extension registration. An exception of type {0} occurred with message:\n{1} and Arguments:\n{2!r}".format(type(ex).__name__, str(ex), ex.args)
@@ -344,13 +419,17 @@ addtask do_registerAgentExtensions after do_install before do_package
 
 fakeroot do_registerAgentExtensions_permissions(){
     chown -R ${ADUUSER}:${ADUGROUP} ${D}${ADUC_UPDATE_CONTENT_HANDLER_EXTENSION_DIR}
+    chown -R ${ADUUSER}:${ADUGROUP} ${D}${ADUC_CONTENT_DOWNLOADER_EXTENSION_DIR}
+    chown -R ${ADUUSER}:${ADUGROUP} ${D}${ADUC_DOWNLOAD_HANDLER_EXTENSION_DIR}
 }
 do_registerAgentExtensions[depends] += "virtual/fakeroot-native:do_populate_sysroot"
 addtask do_registerAgentExtensions_permissions after do_registerAgentExtensions before do_package
 
 FILES:${PN} += "${bindir}/AducIotAgent"
 FILES:${PN} += "${bindir}/adu-shell"
-FILES:${PN} += "${bindir}/adu-swupdate.sh"
+# FILES:${PN} += "${bindir}/adu-delta-test"  # Tool disabled for now
+FILES:${PN} += "/usr/lib/adu/adu-reboot-wrapper.sh"
+# yocto-a-b-update.sh is now deployed by meta-raspberrypi-adu layer (Raspberry Pi specific)
 FILES:${PN} += "${ADUC_DATA_DIR}/* ${ADUC_LOG_DIR}/* ${ADUC_CONF_DIR}/*"
 FILES:${PN} += "${ADUC_EXTENSIONS_DIR}/* ${ADUC_EXTENSIONS_INSTALL_DIR}/* ${ADUC_DOWNLOADS_DIR}/*"
 FILES:${PN} += "${ADUC_COMPONENT_ENUMERATOR_EXTENSION_DIR}/* ${ADUC_CONTENT_DOWNLOADER_EXTENSION_DIR}/* ${ADUC_UPDATE_CONTENT_HANDLER_EXTENSION_DIR}/* ${ADUC_DOWNLOAD_HANDLER_EXTENSION_DIR}/*"

--- a/recipes-azure-device-update/azure-device-update/files/timesyncd.conf
+++ b/recipes-azure-device-update/azure-device-update/files/timesyncd.conf
@@ -1,8 +1,0 @@
-[Time]
-NTP=pool.ntp.org time.google.com time.windows.com
-FallbackNTP=0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org time1.google.com time2.google.com time3.google.com time4.google.com
-RootDistanceMaxSec=5
-PollIntervalMinSec=32
-PollIntervalMaxSec=2048
-ConnectionRetrySec=30
-SaveIntervalSec=60

--- a/recipes-azure-device-update/deliveryoptimization-agent-service/deliveryoptimization-agent-service.bb
+++ b/recipes-azure-device-update/deliveryoptimization-agent-service/deliveryoptimization-agent-service.bb
@@ -17,4 +17,4 @@ FILES:${PN} += "${systemd_system_unitdir}/deliveryoptimization-agent.service"
 REQUIRED_DISTRO_FEATURES = "systemd"
 RDEPENDS:${PN} += "deliveryoptimization-agent"
 
-inherit allarch systemd
+inherit allarch systemd features_check

--- a/recipes-azure-device-update/deliveryoptimization-sdk/deliveryoptimization-sdk.bb
+++ b/recipes-azure-device-update/deliveryoptimization-sdk/deliveryoptimization-sdk.bb
@@ -15,7 +15,43 @@ DO_GIT_COMMIT ?= "b61de2d347c8032562056b18f90ec710e531baf8"
 SRCREV = "${DO_GIT_COMMIT}"
 
 PV = "1.0+git${SRCPV}"
-S = "${WORKDIR}/git" 
+S = "${WORKDIR}/git"
+
+# Local source support for development
+# Enable: Set USE_LOCAL_DO_SOURCE=1 and ensure it's passed through to BitBake:
+#   BB_ENV_PASSTHROUGH_ADDITIONS="USE_LOCAL_DO_SOURCE DO_LOCAL_SOURCE_DIR"
+# Override default path: export DO_LOCAL_SOURCE_DIR=/custom/path
+# See layer README.md for usage examples
+DO_LOCAL_SOURCE_DIR ?= "${TOPDIR}/../../../sources/do-client"
+
+python __anonymous() {
+    import os
+    
+    use_local = d.getVar('USE_LOCAL_DO_SOURCE')
+    local_src = d.getVar('DO_LOCAL_SOURCE_DIR')
+    
+    if use_local == "1":
+        if local_src and os.path.exists(local_src):
+            bb.warn("=" * 60)
+            bb.warn("Using LOCAL DO source from: %s" % local_src)
+            bb.warn("GitHub fetch: DISABLED")
+            bb.warn("Patches: NOT APPLIED (apply manually if needed)")
+            bb.warn("=" * 60)
+            
+            # Set EXTERNALSRC to use local directory
+            d.setVar('EXTERNALSRC', local_src)
+            d.setVar('EXTERNALSRC_BUILD', local_src + '/build-yocto')
+            
+            # Disable fetch and unpack tasks (source already available)
+            d.setVarFlag('do_fetch', 'noexec', '1')
+            d.setVarFlag('do_unpack', 'noexec', '1')
+            d.setVarFlag('do_patch', 'noexec', '1')
+            
+            # Mark as externally provided
+            d.setVar('EXTERNALSRC_SYMLINKS', '')
+        else:
+            bb.fatal("USE_LOCAL_DO_SOURCE=1 but directory not found: %s" % local_src)
+} 
 
 
 

--- a/recipes-azure-iot-sdk-c/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
+++ b/recipes-azure-iot-sdk-c/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
@@ -33,6 +33,16 @@ do_install:append(){
 	install -d ${D}
 	echo "This package is linked against during compilation" > ${D}/azure-iot-sdk-c-placeholder-file
 	echo "Therefore, there is nothing to install on the target" >> ${D}/azure-iot-sdk-c-placeholder-file
+	
+	# Fix hardcoded TMPDIR paths in CMake target files
+	# Replace absolute paths to libraries with just the library names
+	# This prevents buildpaths QA warnings and makes the package relocatable
+	for cmakefile in $(find ${D} -name "*Targets*.cmake" -o -name "*Config.cmake"); do
+		sed -i \
+			-e 's#${TMPDIR}[^;)]*recipe-sysroot/usr/lib/\([^.]*\.so[^;)]*\)#\1#g' \
+			-e 's#${STAGING_DIR_TARGET}/usr/lib/\([^.]*\.so[^;)]*\)#\1#g' \
+			"$cmakefile"
+	done
 }
 
 FILES:${PN} += " \

--- a/recipes-azure-iot-sdk-c/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
+++ b/recipes-azure-iot-sdk-c/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
@@ -14,6 +14,42 @@ PV = "1.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 
+# Local source support for development
+# Enable: Set USE_LOCAL_AZIOT_SDK_C_SOURCE=1 and ensure it's passed through to BitBake:
+#   BB_ENV_PASSTHROUGH_ADDITIONS="USE_LOCAL_AZIOT_SDK_C_SOURCE AZIOT_SDK_C_LOCAL_SOURCE_DIR"
+# Override default path: export AZIOT_SDK_C_LOCAL_SOURCE_DIR=/custom/path
+# See layer README.md for usage examples
+AZIOT_SDK_C_LOCAL_SOURCE_DIR ?= "${TOPDIR}/../../../sources/azure-iot-sdk-c"
+
+python __anonymous() {
+    import os
+    
+    use_local = d.getVar('USE_LOCAL_AZIOT_SDK_C_SOURCE')
+    local_src = d.getVar('AZIOT_SDK_C_LOCAL_SOURCE_DIR')
+    
+    if use_local == "1":
+        if local_src and os.path.exists(local_src):
+            bb.warn("=" * 60)
+            bb.warn("Using LOCAL Azure IoT SDK C source from: %s" % local_src)
+            bb.warn("GitHub fetch: DISABLED")
+            bb.warn("Patches: NOT APPLIED (apply manually if needed)")
+            bb.warn("=" * 60)
+            
+            # Set EXTERNALSRC to use local directory
+            d.setVar('EXTERNALSRC', local_src)
+            d.setVar('EXTERNALSRC_BUILD', local_src + '/build-yocto')
+            
+            # Disable fetch and unpack tasks (source already available)
+            d.setVarFlag('do_fetch', 'noexec', '1')
+            d.setVarFlag('do_unpack', 'noexec', '1')
+            d.setVarFlag('do_patch', 'noexec', '1')
+            
+            # Mark as externally provided
+            d.setVar('EXTERNALSRC_SYMLINKS', '')
+        else:
+            bb.fatal("USE_LOCAL_AZIOT_SDK_C_SOURCE=1 but directory not found: %s" % local_src)
+}
+
 # util-linux for uuid-dev
 DEPENDS = "util-linux curl openssl boost cpprest libproxy msft-gsl"
 

--- a/recipes-azure-sdk-for-cpp/azure-sdk-for-cpp/azure-sdk-for-cpp_git.bb
+++ b/recipes-azure-sdk-for-cpp/azure-sdk-for-cpp/azure-sdk-for-cpp_git.bb
@@ -25,6 +25,19 @@ DEPENDS = "util-linux curl openssl libxml2 opentelemetry-cpp"
 
 inherit cmake
 
+do_install:append() {
+    # Fix hardcoded TMPDIR paths in CMake target files
+    # Replace absolute paths to libraries with just the library names
+    # This prevents buildpaths QA warnings and makes the package relocatable
+    
+    for cmakefile in $(find ${D}${datadir} -name "*Targets*.cmake"); do
+        sed -i \
+            -e 's#${TMPDIR}[^;)]*recipe-sysroot/usr/lib/\([^.]*\.so\)[^;)]*#\1#g' \
+            -e 's#${STAGING_DIR_TARGET}/usr/lib/\([^.]*\.so\)[^;)]*#\1#g' \
+            "$cmakefile"
+    done
+}
+
 sysroot_stage_all:append () {
     sysroot_stage_dir ${D}${exec_prefix}/cmake ${SYSROOT_DESTDIR}${exec_prefix}/cmake
 }


### PR DESCRIPTION
Sync the `scarthgap` branch with `feature/vnext-delta` (source of truth).

`scarthgap` had 2 unique merge commits (catch2 fixes from PRs #24 and #25) that diverged from `feature/vnext-delta`. After investigation, the file changes from those commits are already present in `feature/vnext-delta`, so no content is lost.

This PR uses a sync branch built from `feature/vnext-delta` with a `-s ours` merge of `scarthgap` so the final tree is identical to `feature/vnext-delta` while preserving graph history. After merging, `scarthgap` == `feature/vnext-delta` tree-wise.

A follow-up PR will then sync `scarthgap` -> `main`.