### PR TITLE
scarthgap: pin iot-hub-device-update to tag 1.3.0

### DIFF
--- a/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
+++ b/recipes-azure-device-update/azure-device-update/azure-device-update_git.bb
@@ -29,11 +29,11 @@ ADU_GENERATION ?= "1"
 ADU_EMBED_TEST_ROOT_KEYS ?= "0"
 
 # For gen1, the release come out of develop branch, not main.
-ADU_GIT_BRANCH ?= "feature/vnext-delta"
+ADU_GIT_BRANCH ?= "develop"
 ADU_SRC_URI ?= "git://github.com/Azure/iot-hub-device-update"
 ADU_GIT_PROTOCOL ?= "https"
 SRC_URI = "${ADU_SRC_URI};protocol=${ADU_GIT_PROTOCOL};branch=${ADU_GIT_BRANCH}"
-ADU_GIT_COMMIT ?= "5b169864a9f6789368f0b701afb4df02018be677"
+ADU_GIT_COMMIT ?= "2f3c9b7b7d1a827d9d8755b0c8b889ff52fc69d4"
 # CMake build types: "Release" "RelWithDebInfo" "MinSizeRel"
 BUILD_TYPE ?= "Debug"
 
@@ -155,7 +155,7 @@ python() {
 
 SRCREV = "${ADU_GIT_COMMIT}"
 
-PV = "1.1+git${SRCPV}"
+PV = "1.3.0+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 # DEPENDS are the build-time dependencies that must be built


### PR DESCRIPTION
Pin the azure-device-update recipe to the tag `1.3.0` commit (`2f3c9b7b`) of `Azure/iot-hub-device-update` on the `scarthgap` branch.

### Changes (`recipes-azure-device-update/azure-device-update/azure-device-update_git.bb`)

| Variable | Before | After |
|---|---|---|
| `ADU_GIT_BRANCH` | `feature/vnext-delta` | `develop` |
| `ADU_GIT_COMMIT` | `5b169864a9f6789368f0b701afb4df02018be677` | `2f3c9b7b7d1a827d9d8755b0c8b889ff52fc69d4` |
| `PV` | `1.1+git${SRCPV}` | `1.3.0+git${SRCPV}` |

### Why `develop`?

Yocto requires the SRCREV to be reachable from the branch named in `SRC_URI`. Tag `1.3.0` in `Azure/iot-hub-device-update` points at commit `2f3c9b7b`, which is the head of `develop` and is **not** reachable from `feature/vnext-delta` or `main`. Switching the branch to `develop` satisfies the constraint while pinning to the exact tag commit via `ADU_GIT_COMMIT`.

### Scope

Applied to `scarthgap` only. `feature/vnext-delta` will intentionally diverge here (per direction received).